### PR TITLE
Relicense to Apache 2.0 and bump to v0.5.0-beta

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,201 @@
-BSD 3-Clause License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025-2026, SwiftPandas Contributors
-All rights reserved.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+   1. Definitions.
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025-2026 SwiftPandas Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,26 @@
+SwiftPandas
+Copyright 2025-2026 SwiftPandas Contributors
+
+This product includes software developed by:
+
+  * The pandas development team (https://github.com/pandas-dev/pandas)
+    Copyright (c) 2008-2024, AQR Capital Management, LLC, Lambda Foundry, Inc.
+    and PyData Development Team. All rights reserved.
+    Licensed under the BSD 3-Clause License.
+
+  * Attractive Chaos -- klib (khash) (https://github.com/attractivechaos/klib)
+    Copyright (c) 2008- Attractive Chaos <attractor@live.co.uk>
+    Licensed under the MIT License.
+
+  * ESN Social Software AB and Jonas Tarnstrom -- UltraJSON
+    (https://github.com/ultrajson/ultrajson)
+    Copyright (c) 2011-2013, ESN Social Software AB and Jonas Tarnstrom.
+    All rights reserved. Licensed under the BSD 2-Clause License.
+
+  * Skiplist data structure, originally written by Raymond Hettinger as a
+    Python recipe and ported to C by Wes McKinney for the pandas project.
+    Copyright (c) 2008-2023 the pandas development team.
+    Licensed under the BSD 3-Clause License.
+
+The full text of each upstream license is available in the LICENSES/
+directory of this distribution.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="swift_pandas.png" alt="SwiftPandas" width="400">
 </p>
 
-# SwiftPandas v0.4.0-beta
+# SwiftPandas v0.5.0-beta
 
 > **BETA RELEASE** — This library is under active development and testing. APIs may change between releases. We welcome bug reports and feedback via [GitHub Issues](https://github.com/kiraa-ai/kiraa-swift-pandas/issues).
 
@@ -634,8 +634,8 @@ Both Swift and Python benchmarks are compiled with full optimizations:
 
 ### Benchmark Results
 
-**Scorecard: Swift wins 23 | pandas wins 7** (30 benchmarks)
-**Overall: SwiftPandas is 25.7% faster than pandas on average**
+    **Scorecard: Swift wins 23 | pandas wins 7** (30 benchmarks)
+    **Overall: SwiftPandas is 25.7% faster than pandas on average**
 
 | Operation | SwiftPandas | Python pandas | Winner | vs Python |
 |---|---|---|---|---|
@@ -760,11 +760,11 @@ Both Swift and Python benchmarks are compiled with full optimizations:
 
 ## License
 
-This project is licensed under the BSD 3-Clause License, consistent with the original pandas project.
+This project is licensed under the [Apache License, Version 2.0](LICENSE).
 
 The vendored C libraries retain their original licenses:
 - klib (khash): MIT License
 - UltraJSON: BSD License
 - Skiplist: BSD License
 
-See the [pandas LICENSE](https://github.com/pandas-dev/pandas/blob/main/LICENSE) for the original project license.
+The original pandas project, from which this work is derived, is licensed under the [BSD 3-Clause License](https://github.com/pandas-dev/pandas/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -760,11 +760,52 @@ Both Swift and Python benchmarks are compiled with full optimizations:
 
 ## License
 
-This project is licensed under the [Apache License, Version 2.0](LICENSE).
+SwiftPandas is licensed under the [Apache License, Version 2.0](LICENSE) (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at:
 
-The vendored C libraries retain their original licenses:
-- klib (khash): MIT License
-- UltraJSON: BSD License
-- Skiplist: BSD License
+> http://www.apache.org/licenses/LICENSE-2.0
 
-The original pandas project, from which this work is derived, is licensed under the [BSD 3-Clause License](https://github.com/pandas-dev/pandas/blob/main/LICENSE).
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an **"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND**, either express or implied. See the [License](LICENSE) for the specific language governing permissions and limitations under the License.
+
+```
+Copyright 2025-2026 SwiftPandas Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+```
+
+### Required notices for redistribution
+
+If you redistribute SwiftPandas (in source or binary form, modified or unmodified), Apache 2.0 §4 requires that you:
+
+1. Include a copy of the [LICENSE](LICENSE) file with the distribution.
+2. Include the [NOTICE](NOTICE) file (or its contents) in your distribution, displayed wherever third-party notices normally appear.
+3. Mark any modified files with prominent notices stating that you changed them.
+4. Retain all copyright, patent, trademark, and attribution notices from the source.
+
+The [NOTICE](NOTICE) file lists the upstream projects whose code is incorporated into SwiftPandas and must be carried forward in any derivative work.
+
+### Attribution to the original pandas project
+
+SwiftPandas is a Swift port of, and incorporates code from, the [pandas](https://github.com/pandas-dev/pandas) project, which is licensed under the [BSD 3-Clause License](https://github.com/pandas-dev/pandas/blob/main/LICENSE).
+
+> Copyright (c) 2008-2024, AQR Capital Management, LLC, Lambda Foundry, Inc. and PyData Development Team. All rights reserved.
+
+The relicensing of SwiftPandas to Apache 2.0 applies only to the original Swift code and project-specific work in this repository. The vendored upstream sources continue to be governed by their original licenses (listed below), as permitted by each upstream license.
+
+### Vendored third-party components
+
+The following third-party components are compiled directly into SwiftPandas as framework targets and retain their original licenses. The full text of each license is included in the [LICENSES/](LICENSES/) directory of this repository.
+
+| Component | Upstream | License | Full text |
+|-----------|----------|---------|-----------|
+| **klib (khash)** | [attractivechaos/klib](https://github.com/attractivechaos/klib) | MIT | [LICENSES/KLIB_LICENSE](LICENSES/KLIB_LICENSE) |
+| **UltraJSON** | [ultrajson/ultrajson](https://github.com/ultrajson/ultrajson) | BSD 2-Clause | [LICENSES/ULTRAJSON_LICENSE](LICENSES/ULTRAJSON_LICENSE) |
+| **Skiplist** | Raymond Hettinger / Wes McKinney (pandas) | BSD 3-Clause | [LICENSES/SKIPLIST_LICENSE](LICENSES/SKIPLIST_LICENSE) |
+| **pandas** (algorithms ported to Swift) | [pandas-dev/pandas](https://github.com/pandas-dev/pandas) | BSD 3-Clause | [pandas LICENSE](https://github.com/pandas-dev/pandas/blob/main/LICENSE) |
+
+### Contributions
+
+By submitting a contribution to SwiftPandas, you agree, per Apache 2.0 §5, that your contribution is licensed under the same Apache License, Version 2.0, without any additional terms or conditions.


### PR DESCRIPTION
## Summary
- Switch project license from BSD 3-Clause to Apache License 2.0
- Update README license section to reference Apache 2.0; retain attribution to original BSD-licensed pandas project
- Bump version header in README from v0.4.0-beta to v0.5.0-beta

## Test plan
- [ ] Confirm LICENSE renders as Apache 2.0 on GitHub
- [ ] Confirm README license section reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)