### PR TITLE
docs: align overview and CLI install pattern with v0.5.0-beta distribution

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,16 +5,18 @@
 ### Option A: Download the binary (recommended)
 
 ```bash
-# Download the latest release
-gh release download --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
+# Download the latest CLI binary release
+gh release download --repo kiraa-ai/kiraa-swift-pandas --pattern 'swiftpandas-*-macos*.zip'
 
 # Extract and install
-unzip swiftpandas-*.zip
+unzip swiftpandas-*-macos*.zip
 sudo cp swiftpandas /usr/local/bin/
 
 # Verify
 swiftpandas --help
 ```
+
+> The pattern excludes `SwiftPandas.xcframework.zip`, which is the prebuilt **library** for SwiftPM consumers — see the main README's *Installation → Option B* for that workflow.
 
 ### Option B: Build from source
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > **BETA RELEASE** — This library is under active development and testing. APIs may change between releases. We welcome bug reports and feedback via [GitHub Issues](https://github.com/kiraa-ai/kiraa-swift-pandas/issues).
 
-A native Swift port of the [Python pandas](https://github.com/pandas-dev/pandas) data analysis library, targeting **macOS** with **Metal GPU acceleration** for compute-heavy operations and a **Polars-style lazy evaluation engine** with query optimization.
+A native Swift port of the [Python pandas](https://github.com/pandas-dev/pandas) data analysis library for **macOS and iOS**, with **Metal GPU acceleration** for compute-heavy operations and a **Polars-style lazy evaluation engine** with query optimization. Linux source builds are supported with reduced functionality (no Accelerate, no Metal).
 
 SwiftPandas provides `DataFrame`, `Series`, and `Index` types for tabular data manipulation in Swift, with compiled C libraries (khash, skiplist, UltraJSON) for performance-critical operations, Apple Accelerate/vDSP for SIMD vectorization, Metal compute shaders for GPU-accelerated GroupBy and Merge, and a lazy evaluation engine with filter fusion, predicate pushdown, and projection pushdown.
 


### PR DESCRIPTION
## Summary

Two small doc fixes following the XCFramework distribution merged in #2:

- **README overview** (line 9) now says SwiftPandas targets *macOS and iOS*, with Linux as a reduced-functionality source build. The previous wording predated iOS support.
- **QUICKSTART CLI install pattern** narrowed from `*.zip` to `swiftpandas-*-macos*.zip` so it doesn't pull down `SwiftPandas.xcframework.zip` (which is the library, not the CLI).

## Verification

- Smoke-tested binary mode end-to-end against the published v0.5.0-beta release with a scratch consumer:

  \`\`\`
  SWIFTPANDAS_USE_BINARY=1 swift run
  SwiftPandas 0.5.0-beta
  ┌───┬───┬───┐
  │   │ a │ b │
  ├───┼───┼───┤
  │ 0 │ 1 │ 2 │
  │ 1 │ 3 │ 4 │
  └───┴───┴───┘
  [2 rows x 2 columns]
  \`\`\`

## Test plan

- [x] Render README on GitHub, confirm overview reads correctly
- [x] Confirm `gh release download --pattern 'swiftpandas-*-macos*.zip'` matches the intended CLI artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)