### PR TITLE
fix: tap formula syntax + daemon self-exec path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,12 @@ jobs:
             sha256  "${SHA256}"
             version "${VERSION}"
 
-            head "https://github.com/kiraa-ai/kiraa-swift-pandas.git", branch: "main"
-
             depends_on macos: :ventura
-            depends_on xcode: ["15.0", :build] => :head
+
+            head do
+              url "https://github.com/kiraa-ai/kiraa-swift-pandas.git", branch: "main"
+              depends_on xcode: ["15.0", :build]
+            end
 
             def install
               if build.head?

--- a/Sources/SwiftPandasCLI/Server/Daemon.swift
+++ b/Sources/SwiftPandasCLI/Server/Daemon.swift
@@ -196,11 +196,22 @@ public enum Daemon {
             // Stale — runForeground will clean it up after exec.
         }
 
-        // Resolve our own binary path (CommandLine.arguments[0] is what the
-        // shell exec'd us as; resolve symlinks for a stable re-exec path).
-        let selfPath = URL(fileURLWithPath: CommandLine.arguments[0])
-            .resolvingSymlinksInPath()
-            .path
+        // Resolve our own binary path. `CommandLine.arguments[0]` is only
+        // reliable when the binary was invoked with an absolute path — when
+        // it's resolved via PATH (e.g. /opt/homebrew/bin/swiftpandas → "swiftpandas"),
+        // arguments[0] is just the basename and URL(fileURLWithPath:) treats
+        // it as relative to CWD, producing a path that doesn't exist.
+        //
+        // Bundle.main.executablePath calls _NSGetExecutablePath() under the
+        // hood, which returns the actual executable path regardless of how
+        // the process was launched. Fall back to the old behaviour if that
+        // ever returns nil (shouldn't happen for a real binary).
+        let selfPath: String = {
+            if let bundlePath = Bundle.main.executablePath {
+                return URL(fileURLWithPath: bundlePath).resolvingSymlinksInPath().path
+            }
+            return URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath().path
+        }()
 
         let child = Process()
         child.executableURL = URL(fileURLWithPath: selfPath)


### PR DESCRIPTION
## Summary

Two related fixes that landed during the v0.6.0-beta release attempt:

### 1. Tap formula syntax error (`depends_on … => :head`)

`depends_on xcode: ["15.0", :build] => :head` is invalid Homebrew DSL. Ruby parses the `=> :head` suffix as a hash-literal continuation and the formula refuses to load:

\`\`\`
/opt/homebrew/Library/Taps/kiraa-ai/homebrew-tap/Formula/swiftpandas.rb:20: syntax errors found
  depends_on xcode: ["15.0", :build] => :head
                                      ^~ unexpected '=>'
\`\`\`

Replace with the canonical `head do … end` block that wraps the head URL and the head-only Xcode dependency.

The tap formula has already been hot-fixed directly so installs work right now: [kiraa-ai/homebrew-tap@53f6d9a](https://github.com/kiraa-ai/homebrew-tap/commit/53f6d9a). This PR keeps the workflow in sync so the next release won't regenerate the broken version.

### 2. Daemon `spawnBackground` self-exec path

`swiftpandas server start` (the backgrounded path) re-execs itself with `--foreground`. The previous resolver used `CommandLine.arguments[0]`, which is only reliable when the binary was invoked with an absolute path. When the user runs the brew-installed binary via `swiftpandas` on PATH, arguments[0] is just `"swiftpandas"` and `URL(fileURLWithPath:)` treats it as relative to CWD:

\`\`\`
swiftpandas: failed to spawn daemon:
  The file "swiftpandas" doesn't exist.
  NSFilePath=/Users/e2mq173/Projects/Cursor/swift-pandas/swiftpandas
\`\`\`

Switch to `Bundle.main.executablePath`, which calls `_NSGetExecutablePath()` under the hood and returns the real on-disk path regardless of how the process was launched. Keep the old fallback if Bundle.main returns nil.

## Test plan

- [x] `ruby -c` against the generated formula → `Syntax OK`
- [x] Tap hot-fix confirmed installable via `brew install kiraa-ai/tap/swiftpandas`
- [x] Local-build end-to-end smoke test (`swiftpandas-brew-test.sh` against `SWIFTPANDAS_BIN=$(pwd)/.build/release/swiftpandas`):
  - 200,000-row CSV generated
  - daemon backgrounded successfully
  - load + aggregate + save round trip
  - daemon stops cleanly
- [x] `swift test` — 415/415 passing, no regressions

## Follow-up

After this merges, cut v0.6.1-beta via `scripts/build-release.sh v0.6.1-beta`. The (now-corrected) release.yml will regenerate the tap formula on publish, and `brew upgrade swiftpandas` will pick up the daemon fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)