### PR TITLE
v0.8.0-beta: vector columns, similarity search, SPB binary IO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,8 +55,8 @@ let useBinary = ProcessInfo.processInfo.environment["SWIFTPANDAS_USE_BINARY"] ==
 // every tagged release: scripts/build-xcframework.sh prints the new
 // checksum after building, and the asset must be uploaded to the matching
 // GitHub release before consumers can resolve the binary target.
-let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.6.1-beta/SwiftPandas.xcframework.zip"
-let xcframeworkChecksum = "552da052b166d9bf34485d485456357c3120e1f152b225821846575b5cbb892f"
+let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.0-beta/SwiftPandas.xcframework.zip"
+let xcframeworkChecksum = "86efd4f87d788523d8b9a474e8d6a7059bec52174f56113945ec3ede1085e3c2"
 
 // ── Source-mode targets ──
 let sourceTargets: [Target] = [

--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,11 @@ let sourceTargets: [Target] = [
         name: "SwiftPandas",
         dependencies: ["CSkipList", "CKHash", "CUltraJSON"],
         path: "Sources/SwiftPandas",
-        exclude: ["Metal/Shaders/GroupByShaders.metal", "Metal/Shaders/MergeShaders.metal"],
+        exclude: [
+            "Metal/Shaders/GroupByShaders.metal",
+            "Metal/Shaders/MergeShaders.metal",
+            "Metal/Shaders/VectorSearchShaders.metal",
+        ],
         swiftSettings: [
             .define("ACCELERATE_AVAILABLE", .when(platforms: [.macOS, .iOS])),
             .unsafeFlags(["-O"]),

--- a/Sources/SwiftPandas/Core/Array/Column.swift
+++ b/Sources/SwiftPandas/Core/Array/Column.swift
@@ -84,6 +84,17 @@ public enum Column: CustomStringConvertible, Sendable {
     /// needed.
     case int64(NullableArray<Int64>)
 
+    /// A fixed-dims Float32 vector column backed by ``VectorArray``.
+    ///
+    /// Vectors are stored as one flat, contiguous, row-major plane
+    /// (`count * dims` floats) plus a validity bitmap — never as an
+    /// array-of-arrays. Null rows are zero-filled in the plane (normative for
+    /// deterministic SPB bytes). Vector columns are non-numeric-scalar:
+    /// ``asDouble()`` returns `nil`, so scalar aggregations skip them the same
+    /// way they skip strings. Like `.bool`, take/copy require manual handling
+    /// (a `[Float]` row is not `ExpressibleByIntegerLiteral`).
+    case floatVector(VectorArray)
+
     // MARK: - Properties
 
     /// The number of elements in this column (including NAs).
@@ -93,6 +104,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return a.count
         case .bool(let a): return a.count
         case .int64(let a): return a.count
+        case .floatVector(let a): return a.count
         }
     }
 
@@ -107,6 +119,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string: return .string
         case .bool: return .bool
         case .int64: return .int64
+        case .floatVector(let a): return .floatVector(dims: a.dims)
         }
     }
 
@@ -130,6 +143,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return a.validCount
         case .bool(let a): return a.validCount
         case .int64(let a): return a.validCount
+        case .floatVector(let a): return a.validCount
         }
     }
 
@@ -151,6 +165,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return a.isNA()
         case .bool(let a): return a.isNA()
         case .int64(let a): return a.isNA()
+        case .floatVector(let a): return a.isNA()
         }
     }
 
@@ -165,6 +180,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return a.nbytes
         case .bool(let a): return a.nbytes
         case .int64(let a): return a.nbytes
+        case .floatVector(let a): return a.nbytes
         }
     }
 
@@ -204,6 +220,9 @@ public enum Column: CustomStringConvertible, Sendable {
         case .int64(let a):
             guard let v = a[index] else { return "NA" }
             return "\(v)"
+        case .floatVector(let a):
+            guard a.row(index) != nil else { return "NA" }
+            return "<vector[\(a.dims)]>"
         }
     }
 
@@ -222,6 +241,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return a[index]
         case .bool(let a): return a[index]
         case .int64(let a): return a[index]
+        case .floatVector(let a): return a.row(index)
         }
     }
 
@@ -246,7 +266,11 @@ public enum Column: CustomStringConvertible, Sendable {
         case .int64(let a):
             let doubleData = NativeArray<Double>(a.data.array.map { Double($0) })
             return NullableArray(data: doubleData, mask: a.mask)
-        default: return nil
+        case .string, .bool, .floatVector:
+            // Explicit (not `default:`) per the vector exhaustive-switch
+            // audit: there is no scalar-numeric promotion for these dtypes,
+            // so numeric aggregations skip them.
+            return nil
         }
     }
 
@@ -347,6 +371,7 @@ public enum Column: CustomStringConvertible, Sendable {
             }
             return .bool(NullableArray(data: NativeArray(values), mask: BitVector(bools)))
         case .int64(let a): return .int64(a.take(indices: indices))
+        case .floatVector(let a): return .floatVector(a.take(indices: indices))
         }
     }
 
@@ -386,6 +411,7 @@ public enum Column: CustomStringConvertible, Sendable {
             }
             return .bool(NullableArray(data: NativeArray(values), mask: BitVector(bools)))
         case .int64(let a): return .int64(a.take(mask: mask, trueCount: trueCount))
+        case .floatVector(let a): return .floatVector(a.take(mask: mask, trueCount: trueCount))
         }
     }
 
@@ -402,6 +428,7 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return .string(a.copy())
         case .bool(let a): return .bool(a.copy())
         case .int64(let a): return .int64(a.copy())
+        case .floatVector(let a): return .floatVector(a.copy())
         }
     }
 
@@ -456,6 +483,8 @@ public enum Column: CustomStringConvertible, Sendable {
         case .string(let a): return a.description
         case .bool(let a): return a.description
         case .int64(let a): return a.description
+        case .floatVector(let a):
+            return "VectorArray(count: \(a.count), dims: \(a.dims), nulls: \(a.count - a.validCount))"
         }
     }
 }
@@ -469,6 +498,7 @@ extension Column: Equatable {
         case (.string(let a), .string(let b)): return a == b
         case (.bool(let a), .bool(let b)): return a == b
         case (.int64(let a), .int64(let b)): return a == b
+        case (.floatVector(let a), .floatVector(let b)): return a == b
         default: return false
         }
     }
@@ -485,6 +515,21 @@ extension Column {
             if let v = v { data[i] = Int64(v); valid[i] = true }
         }
         return .int64(NullableArray(data: NativeArray(data), mask: BitVector(valid)))
+    }
+
+    /// Creates a `.floatVector` column from dense vectors.
+    ///
+    /// - Throws: ``VectorError/dimensionMismatch(expected:got:)`` if any
+    ///   element's count differs from `dims`;
+    ///   ``VectorError/invalidArgument(_:)`` if `dims < 1`.
+    public static func fromVectors(_ vectors: [[Float]], dims: Int) throws -> Column {
+        .floatVector(try VectorArray(vectors: vectors, dims: dims))
+    }
+
+    /// Creates a `.floatVector` column from optional vectors; `nil` elements
+    /// become null rows (bitmap-cleared, zero-filled plane slot).
+    public static func fromOptionalVectors(_ vectors: [[Float]?], dims: Int) throws -> Column {
+        .floatVector(try VectorArray(vectors: vectors, dims: dims))
     }
 
     /// Creates a column from an array of optional booleans.

--- a/Sources/SwiftPandas/Core/DType/DType.swift
+++ b/Sources/SwiftPandas/Core/DType/DType.swift
@@ -223,6 +223,11 @@ public enum DTypeEnum: Hashable, CustomStringConvertible, Sendable {
     case string
     case datetime
     case timedelta
+    /// A fixed-dimensionality Float32 vector column. The dimensionality is
+    /// part of the type identity (like Arrow's `FixedSizeList<Float32>[d]`):
+    /// two vector columns with different dims compare dtype-unequal, which
+    /// gives `concat`/SPB dims validation for free.
+    case floatVector(dims: Int)
 
     /// A pandas-compatible string representation of this dtype.
     ///
@@ -244,6 +249,7 @@ public enum DTypeEnum: Hashable, CustomStringConvertible, Sendable {
         case .string: return "string"
         case .datetime: return "datetime64[ns]"
         case .timedelta: return "timedelta64[ns]"
+        case .floatVector(let dims): return "floatVector(\(dims))"
         }
     }
 

--- a/Sources/SwiftPandas/DataFrame/DataFrame+JoinIndex.swift
+++ b/Sources/SwiftPandas/DataFrame/DataFrame+JoinIndex.swift
@@ -115,6 +115,11 @@ extension DataFrame {
         case .bool(let a):
             guard let v = a[row] else { return "" }
             return v ? "True" : "False"
+        case .floatVector:
+            // Vector columns are rejected as join keys before any key-text
+            // path runs (merge throws VectorError.unsupportedOperation); this
+            // arm exists only to keep the switch exhaustive without `default:`.
+            return ""
         }
     }
 }

--- a/Sources/SwiftPandas/DataFrame/DataFrame.swift
+++ b/Sources/SwiftPandas/DataFrame/DataFrame.swift
@@ -713,7 +713,10 @@ public struct DataFrame: CustomStringConvertible, Sendable {
                 }
             case .string(let a):
                 sortKeys.append(.string(a, asc))
-            default:
+            case .bool, .floatVector:
+                // No ordering defined; the column is skipped as a sort key
+                // (explicit cases rather than `default:` per the vector
+                // exhaustive-switch audit).
                 break
             }
         }
@@ -822,7 +825,9 @@ public struct DataFrame: CustomStringConvertible, Sendable {
                 }
                 indices = validPositions + naPositions
             }
-        default:
+        case .bool, .floatVector:
+            // No ordering defined; returning the frame unchanged matches the
+            // long-standing `.bool` behavior of this non-throwing API.
             return self
         }
         return takeRows(indices)
@@ -1130,6 +1135,21 @@ public struct DataFrame: CustomStringConvertible, Sendable {
                 }
                 let combinedMask = BitVector.concat(masks)
                 resultCols.append((name, .bool(NullableArray(data: combinedData, mask: combinedMask))))
+            case .floatVector(let firstArr):
+                var arrays = [VectorArray]()
+                arrays.reserveCapacity(frames.count)
+                for frame in frames {
+                    guard case .floatVector(let arr) = frame.columns[name] else { continue }
+                    arrays.append(arr)
+                }
+                // concat is non-throwing; mismatched dims across frames is a
+                // schema violation on par with mismatched dtypes, surfaced as
+                // a precondition rather than silently dropping rows.
+                guard let combined = try? VectorArray.concat(arrays) else {
+                    preconditionFailure(
+                        "concat: floatVector column '\(name)' has mismatched dims across frames (expected \(firstArr.dims))")
+                }
+                resultCols.append((name, .floatVector(combined)))
             }
         }
 
@@ -1183,6 +1203,17 @@ public struct DataFrame: CustomStringConvertible, Sendable {
     ) -> DataFrame {
         guard let leftCol = columns[key], let rightCol = right.columns[key] else {
             fatalError("Key column '\(key)' not found in both DataFrames")
+        }
+        if case .floatVector(let a) = leftCol {
+            // Without this guard a vector key would fall into the text-join
+            // fallback, where every valid row shares the placeholder key text
+            // and cross-joins. Consistent with the missing-key fatalError of
+            // this non-throwing API. Vector columns still pass through merges
+            // as payload.
+            fatalError("merge: floatVector(\(a.dims)) columns cannot be join keys")
+        }
+        if case .floatVector(let a) = rightCol {
+            fatalError("merge: floatVector(\(a.dims)) columns cannot be join keys")
         }
 
         // GPU fast path for inner joins on large datasets
@@ -1533,6 +1564,10 @@ public struct GroupBy: Sendable {
             case .int64(let a):
                 let f = a.factorize()
                 codes = f.codes; nUnique = f.uniques.count
+            case .floatVector(let a):
+                // Without this guard all rows would silently collapse into a
+                // single group via the fallback below.
+                preconditionFailure("groupBy: floatVector(\(a.dims)) columns cannot be group keys")
             default:
                 codes = [Int](repeating: 0, count: n); nUnique = 1
             }
@@ -1556,6 +1591,8 @@ public struct GroupBy: Sendable {
                 case .int64(let a):
                     let f = a.factorize()
                     codes = f.codes; nUnique = f.uniques.count
+                case .floatVector(let a):
+                    preconditionFailure("groupBy: floatVector(\(a.dims)) columns cannot be group keys")
                 default:
                     codes = [Int](repeating: 0, count: n); nUnique = 1
                 }

--- a/Sources/SwiftPandas/IO/CSV/CSVReader.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReader.swift
@@ -1176,6 +1176,16 @@ public struct CSVWriter: Sendable {
                 formattedCols.append(strs)
                 needsQuoting.append(false)
 
+            case .floatVector(let arr):
+                // CSV is explicitly out of scope for vector columns (SPB is
+                // the durable format). The throwing toCSV entry points reject
+                // vector frames with VectorError.unsupportedOperation before
+                // reaching this writer; this precondition backstops direct
+                // CSVWriter.write callers, whose signature cannot throw.
+                preconditionFailure(
+                    "CSV serialization is unsupported for floatVector(\(arr.dims)) columns; "
+                    + "drop/select the other columns or use writeSPB")
+
             case .string(let arr):
                 var strs = [String]()
                 strs.reserveCapacity(rowCount)
@@ -1371,9 +1381,21 @@ extension DataFrame {
         index: Bool = false,
         quoting: CSVQuoting = .minimal
     ) throws {
+        try rejectVectorColumns(op: "toCSV")
         let writer = CSVWriter(separator: separator, includeHeader: header,
                                includeIndex: index, quoting: quoting)
         try writer.write(self, toPath: path)
+    }
+
+    /// CSV/JSON serialization is out of scope for vector columns (SPB is the
+    /// durable format). Throwing IO entry points call this before writing;
+    /// callers who want the scalar columns can `drop`/`select` them first.
+    internal func rejectVectorColumns(op: String) throws {
+        for name in columnNames {
+            if case .floatVector(let a) = columns[name]! {
+                throw VectorError.unsupportedOperation(op: op, dtype: "floatVector(\(a.dims))")
+            }
+        }
     }
 
     /// Creates a ``DataFrame`` by reading and parsing a CSV file at the given `URL`.
@@ -1393,6 +1415,7 @@ extension DataFrame {
         header: Bool = true,
         index: Bool = false
     ) throws {
+        try rejectVectorColumns(op: "toCSV")
         let csv = toCSV(separator: separator, header: header, index: index)
         try csv.write(to: url, atomically: true, encoding: .utf8)
     }

--- a/Sources/SwiftPandas/IO/JSON/JSONReader.swift
+++ b/Sources/SwiftPandas/IO/JSON/JSONReader.swift
@@ -171,13 +171,22 @@ extension DataFrame {
     }
 
     /// Writes this ``DataFrame`` to a JSON file at the given path.
+    ///
+    /// - Throws: ``VectorError/unsupportedOperation(op:dtype:)`` if the frame
+    ///   contains a vector column (JSON text serialization of vectors is
+    ///   unspecified; SPB is the durable format for vector frames).
     public func toJSON(path: String) throws {
+        try rejectVectorColumns(op: "toJSON")
         let json = toJSON()
         try json.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
     /// Writes this ``DataFrame`` to a JSON file at the given URL.
+    ///
+    /// - Throws: ``VectorError/unsupportedOperation(op:dtype:)`` if the frame
+    ///   contains a vector column.
     public func toJSON(url: URL) throws {
+        try rejectVectorColumns(op: "toJSON")
         let json = toJSON()
         try json.write(to: url, atomically: true, encoding: .utf8)
     }

--- a/Sources/SwiftPandas/IO/SPB/SPBFormat.swift
+++ b/Sources/SwiftPandas/IO/SPB/SPBFormat.swift
@@ -1,0 +1,140 @@
+// ===----------------------------------------------------------------------===//
+//
+// SPBFormat.swift
+// SwiftPandas
+//
+// The "SPB" (SwiftPandas Binary) format: shared layout constants and the
+// bounds-checked read cursor. SPB is the durable, byte-deterministic format
+// for frames (including vector columns, which CSV/JSON cannot carry).
+//
+// ## Layout (version 1, little-endian throughout)
+//
+//   offset  size        field
+//   0       4           magic "SPB1"
+//   4       4           UInt32 formatVersion = 1
+//   8       4           UInt32 columnCount
+//   12      8           UInt64 rowCount
+//   ...     per column, in frame (columnNames) order:
+//           4 + n         name: UInt32 byteLen + UTF-8
+//           1             dtype tag (0=double, 1=string, 2=bool, 3=int64,
+//                         4=floatVector)
+//           4             UInt32 dims (floatVector only; absent otherwise)
+//           ceil(rows/8)  validity bitmap (LSB-first within each byte,
+//                         trailing bits of the final byte zero)
+//           payload       double/int64: 8B native LE each (null cells zero);
+//                         bool: 1B 0/1 (null cells 0);
+//                         string: per-cell UInt32 byteLen + UTF-8 (null
+//                         cells: len 0; the bitmap disambiguates null from
+//                         empty);
+//                         floatVector: rows*dims*4B Float32 LE plane (null
+//                         rows zero-filled)
+//
+// ## Determinism (normative)
+//
+// Two writes of equal frames produce byte-identical files: fixed layout, no
+// timestamps, column iteration driven by the ordered `columnNames` array
+// (never the backing dictionary), and every null payload slot written as
+// zero. The reader enforces the same canonical form (non-zero null slots are
+// rejected as corrupt), so round-trips cannot silently produce files that
+// differ from a fresh write.
+//
+// `formatVersion` exists so future sections (e.g. an ANN index sidecar) can
+// be appended under version 2 while v1 readers keep failing loudly
+// (`versionUnsupported`) rather than misparsing.
+//
+// ===----------------------------------------------------------------------===//
+
+import Foundation
+
+internal enum SPBFormat {
+    static let magic: [UInt8] = [0x53, 0x50, 0x42, 0x31]  // "SPB1"
+    static let version: UInt32 = 1
+
+    enum DTypeTag: UInt8 {
+        case double = 0
+        case string = 1
+        case bool = 2
+        case int64 = 3
+        case floatVector = 4
+    }
+
+    /// Number of bitmap bytes for a row count.
+    static func bitmapByteCount(rows: Int) -> Int {
+        (rows + 7) / 8
+    }
+}
+
+/// Bounds-checked sequential reader over raw SPB bytes.
+///
+/// Every primitive read validates the remaining byte count and throws
+/// ``VectorError/corrupt(reason:)`` on overrun, so the reader body is
+/// straight-line layout code with no inline bounds arithmetic — truncated or
+/// corrupt files cannot be mishandled at call sites, and no partial
+/// ``DataFrame`` is ever constructed.
+internal struct SPBCursor {
+    private let bytes: [UInt8]
+    private(set) var offset: Int = 0
+
+    init(_ data: Data) {
+        self.bytes = [UInt8](data)
+    }
+
+    var remaining: Int { bytes.count - offset }
+
+    private mutating func require(_ count: Int, what: String) throws {
+        guard count >= 0, remaining >= count else {
+            throw VectorError.corrupt(
+                reason: "truncated file: needed \(count) bytes for \(what) at offset \(offset), "
+                    + "have \(remaining)")
+        }
+    }
+
+    mutating func readBytes(_ count: Int, what: String) throws -> ArraySlice<UInt8> {
+        try require(count, what: what)
+        defer { offset += count }
+        return bytes[offset..<(offset + count)]
+    }
+
+    mutating func readU8(_ what: String) throws -> UInt8 {
+        try require(1, what: what)
+        defer { offset += 1 }
+        return bytes[offset]
+    }
+
+    mutating func readU32(_ what: String) throws -> UInt32 {
+        try require(4, what: what)
+        var value: UInt32 = 0
+        for i in 0..<4 { value |= UInt32(bytes[offset + i]) << (8 * i) }
+        offset += 4
+        return value
+    }
+
+    mutating func readU64(_ what: String) throws -> UInt64 {
+        try require(8, what: what)
+        var value: UInt64 = 0
+        for i in 0..<8 { value |= UInt64(bytes[offset + i]) << (8 * i) }
+        offset += 8
+        return value
+    }
+
+    mutating func readString(byteLength: Int, what: String) throws -> String {
+        let slice = try readBytes(byteLength, what: what)
+        guard let string = String(bytes: slice, encoding: .utf8) else {
+            throw VectorError.corrupt(reason: "invalid UTF-8 in \(what)")
+        }
+        return string
+    }
+}
+
+/// Little-endian append helpers for the writer.
+internal extension Data {
+    mutating func appendU32(_ value: UInt32) {
+        var le = value.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+
+    mutating func appendU64(_ value: UInt64) {
+        var le = value.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+}

--- a/Sources/SwiftPandas/IO/SPB/SPBReader.swift
+++ b/Sources/SwiftPandas/IO/SPB/SPBReader.swift
@@ -1,0 +1,209 @@
+// ===----------------------------------------------------------------------===//
+//
+// SPBReader.swift
+// SwiftPandas
+//
+// SPB bytes -> DataFrame. Every read goes through the bounds-checked
+// SPBCursor; every failure throws before a DataFrame is constructed, so there
+// are no partial loads. The reader also enforces the writer's canonical form
+// (null payload slots must be zero, bitmap tail bits must be zero, string
+// null cells must have length 0), so a successful read implies the file is
+// exactly what a fresh write would produce.
+//
+// ===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension DataFrame {
+    /// Read a DataFrame from SPB bytes.
+    ///
+    /// - Throws: ``VectorError/corrupt(reason:)`` for any validation failure
+    ///   (with a human-readable reason);
+    ///   ``VectorError/versionUnsupported(found:supported:)`` for files newer
+    ///   than format version 1. No partial loads.
+    public static func readSPB(from data: Data) throws -> DataFrame {
+        var cursor = SPBCursor(data)
+
+        let magic = try cursor.readBytes(4, what: "magic")
+        guard Array(magic) == SPBFormat.magic else {
+            throw VectorError.corrupt(reason: "bad magic (expected \"SPB1\")")
+        }
+        let version = try cursor.readU32("formatVersion")
+        guard version <= SPBFormat.version else {
+            throw VectorError.versionUnsupported(found: version, supported: SPBFormat.version)
+        }
+        guard version == SPBFormat.version else {
+            throw VectorError.corrupt(reason: "invalid formatVersion \(version)")
+        }
+        let columnCount = Int(try cursor.readU32("columnCount"))
+        let rowCount64 = try cursor.readU64("rowCount")
+        guard rowCount64 <= UInt64(Int.max) else {
+            throw VectorError.corrupt(reason: "rowCount \(rowCount64) exceeds Int.max")
+        }
+        let rows = Int(rowCount64)
+
+        var resultColumns = [(String, Column)]()
+        resultColumns.reserveCapacity(columnCount)
+        var seenNames = Set<String>()
+
+        for columnIndex in 0..<columnCount {
+            let nameLength = Int(try cursor.readU32("column \(columnIndex) name length"))
+            let name = try cursor.readString(byteLength: nameLength, what: "column \(columnIndex) name")
+            guard seenNames.insert(name).inserted else {
+                throw VectorError.corrupt(reason: "duplicate column name '\(name)'")
+            }
+            let tagByte = try cursor.readU8("column '\(name)' dtype tag")
+            guard let tag = SPBFormat.DTypeTag(rawValue: tagByte) else {
+                throw VectorError.corrupt(reason: "unknown dtype tag \(tagByte) for column '\(name)'")
+            }
+
+            var dims = 0
+            if tag == .floatVector {
+                dims = Int(try cursor.readU32("column '\(name)' dims"))
+                guard dims >= 1 else {
+                    throw VectorError.corrupt(reason: "column '\(name)' has dims \(dims) (must be >= 1)")
+                }
+            }
+
+            let validity = try readBitmap(&cursor, rows: rows, column: name)
+            let column: Column
+            switch tag {
+            case .double:
+                let values: [Double] = try readFixedWidth(
+                    &cursor, rows: rows, column: name, as: Double.self)
+                try requireZeroNullSlots(values, validity, column: name) { $0 == 0 }
+                column = .double(NullableArray(
+                    data: NativeArray(values), mask: validity))
+            case .int64:
+                let values: [Int64] = try readFixedWidth(
+                    &cursor, rows: rows, column: name, as: Int64.self)
+                try requireZeroNullSlots(values, validity, column: name) { $0 == 0 }
+                column = .int64(NullableArray(data: NativeArray(values), mask: validity))
+            case .bool:
+                let bytes = try cursor.readBytes(rows, what: "column '\(name)' bool payload")
+                var values = ContiguousArray<Bool>(repeating: false, count: rows)
+                for (i, byte) in bytes.enumerated() {
+                    switch byte {
+                    case 0: break
+                    case 1:
+                        guard validity[i] else {
+                            throw VectorError.corrupt(
+                                reason: "column '\(name)' row \(i): null bool cell with non-zero payload")
+                        }
+                        values[i] = true
+                    default:
+                        throw VectorError.corrupt(
+                            reason: "column '\(name)' row \(i): invalid bool byte \(byte)")
+                    }
+                }
+                column = .bool(NullableArray(data: NativeArray(values), mask: validity))
+            case .string:
+                var values = [String?](repeating: nil, count: rows)
+                for i in 0..<rows {
+                    let length = Int(try cursor.readU32("column '\(name)' row \(i) string length"))
+                    if validity[i] {
+                        values[i] = try cursor.readString(
+                            byteLength: length, what: "column '\(name)' row \(i) string")
+                    } else {
+                        guard length == 0 else {
+                            throw VectorError.corrupt(
+                                reason: "column '\(name)' row \(i): null string cell with length \(length)")
+                        }
+                    }
+                }
+                column = .string(StringArray(values))
+            case .floatVector:
+                let planeCount: Int
+                let (rowsTimesDims, overflow1) = rows.multipliedReportingOverflow(by: dims)
+                guard !overflow1 else {
+                    throw VectorError.corrupt(reason: "column '\(name)': rows*dims overflows")
+                }
+                planeCount = rowsTimesDims
+                let plane: [Float] = try readFixedWidthCount(
+                    &cursor, count: planeCount, column: name, as: Float.self)
+                // Canonical form: null rows must be zero-filled.
+                for row in 0..<rows where !validity[row] {
+                    for k in 0..<dims where plane[row * dims + k] != 0 {
+                        throw VectorError.corrupt(
+                            reason: "column '\(name)' row \(row): null vector row has non-zero plane data")
+                    }
+                }
+                column = .floatVector(VectorArray(
+                    plane: NativeArray(ContiguousArray(plane)), validity: validity, dims: dims))
+            }
+            resultColumns.append((name, column))
+        }
+
+        guard cursor.remaining == 0 else {
+            throw VectorError.corrupt(
+                reason: "\(cursor.remaining) trailing bytes after last column")
+        }
+        return DataFrame(columns: resultColumns)
+    }
+
+    /// Read a DataFrame from an SPB file.
+    public static func readSPB(from url: URL) throws -> DataFrame {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        return try readSPB(from: data)
+    }
+
+    // MARK: - Helpers
+
+    private static func readBitmap(
+        _ cursor: inout SPBCursor, rows: Int, column: String
+    ) throws -> BitVector {
+        let byteCount = SPBFormat.bitmapByteCount(rows: rows)
+        let bytes = try cursor.readBytes(byteCount, what: "column '\(column)' validity bitmap")
+        var bools = [Bool](repeating: false, count: rows)
+        for (k, byte) in bytes.enumerated() {
+            let base = k * 8
+            for bit in 0..<8 {
+                let index = base + bit
+                let isSet = (byte >> bit) & 1 == 1
+                if index < rows {
+                    bools[index] = isSet
+                } else if isSet {
+                    throw VectorError.corrupt(
+                        reason: "column '\(column)': non-zero bitmap tail bit \(index)")
+                }
+            }
+        }
+        return BitVector(bools)
+    }
+
+    private static func readFixedWidth<T>(
+        _ cursor: inout SPBCursor, rows: Int, column: String, as type: T.Type
+    ) throws -> [T] {
+        try readFixedWidthCount(&cursor, count: rows, column: column, as: type)
+    }
+
+    private static func readFixedWidthCount<T>(
+        _ cursor: inout SPBCursor, count: Int, column: String, as type: T.Type
+    ) throws -> [T] {
+        let stride = MemoryLayout<T>.stride
+        let (byteCount, overflow) = count.multipliedReportingOverflow(by: stride)
+        guard !overflow else {
+            throw VectorError.corrupt(reason: "column '\(column)': payload size overflows")
+        }
+        let slice = try cursor.readBytes(byteCount, what: "column '\(column)' payload")
+        // Little-endian hosts only (see SPBWriter header). copyBytes rather
+        // than bindMemory: the payload offset is unaligned whenever it
+        // follows variable-length string cells.
+        return slice.withUnsafeBytes { raw in
+            [T](unsafeUninitializedCapacity: count) { buffer, initialized in
+                raw.copyBytes(to: UnsafeMutableRawBufferPointer(buffer))
+                initialized = count
+            }
+        }
+    }
+
+    private static func requireZeroNullSlots<T>(
+        _ values: [T], _ validity: BitVector, column: String, isZero: (T) -> Bool
+    ) throws {
+        guard !validity.allValid else { return }
+        for i in 0..<values.count where !validity[i] && !isZero(values[i]) {
+            throw VectorError.corrupt(
+                reason: "column '\(column)' row \(i): null cell has non-zero payload")
+        }
+    }
+}

--- a/Sources/SwiftPandas/IO/SPB/SPBWriter.swift
+++ b/Sources/SwiftPandas/IO/SPB/SPBWriter.swift
@@ -1,0 +1,114 @@
+// ===----------------------------------------------------------------------===//
+//
+// SPBWriter.swift
+// SwiftPandas
+//
+// DataFrame -> SPB bytes. See SPBFormat.swift for the layout and the
+// determinism contract. Column iteration is driven by `columnNames` — the
+// ordered array, never the backing dictionary — which is the single
+// map-iteration-order hazard this format must avoid.
+//
+// Fixed-width payloads use raw buffer copies (SwiftPandas supports
+// little-endian hosts only; Apple Silicon, x86-64, and ARM Linux all
+// qualify), with null slots pre-zeroed so equal frames always produce
+// byte-identical files.
+//
+// ===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension DataFrame {
+    /// Serialize this frame to SPB bytes.
+    public func toSPBData() -> Data {
+        var out = Data()
+        out.reserveCapacity(64 + estimatedBytes + estimatedBytes / 8)
+
+        out.append(contentsOf: SPBFormat.magic)
+        out.appendU32(SPBFormat.version)
+        out.appendU32(UInt32(columnNames.count))
+        out.appendU64(UInt64(rowCount))
+
+        for name in columnNames {
+            let col = columns[name]!
+            let nameBytes = [UInt8](name.utf8)
+            out.appendU32(UInt32(nameBytes.count))
+            out.append(contentsOf: nameBytes)
+
+            switch col {
+            case .double(let a):
+                out.append(SPBFormat.DTypeTag.double.rawValue)
+                appendBitmap(&out, a.mask)
+                if a.mask.allValid {
+                    a.data.withUnsafeBufferPointer { out.append(contentsOf: Data(buffer: $0)) }
+                } else {
+                    // Null slots write as zero for byte-determinism.
+                    var zeroed = ContiguousArray<Double>(repeating: 0, count: a.count)
+                    a.data.withUnsafeBufferPointer { src in
+                        for i in 0..<a.count where a.mask[i] { zeroed[i] = src[i] }
+                    }
+                    zeroed.withUnsafeBufferPointer { out.append(contentsOf: Data(buffer: $0)) }
+                }
+
+            case .int64(let a):
+                out.append(SPBFormat.DTypeTag.int64.rawValue)
+                appendBitmap(&out, a.mask)
+                if a.mask.allValid {
+                    a.data.withUnsafeBufferPointer { out.append(contentsOf: Data(buffer: $0)) }
+                } else {
+                    var zeroed = ContiguousArray<Int64>(repeating: 0, count: a.count)
+                    a.data.withUnsafeBufferPointer { src in
+                        for i in 0..<a.count where a.mask[i] { zeroed[i] = src[i] }
+                    }
+                    zeroed.withUnsafeBufferPointer { out.append(contentsOf: Data(buffer: $0)) }
+                }
+
+            case .bool(let a):
+                out.append(SPBFormat.DTypeTag.bool.rawValue)
+                appendBitmap(&out, a.mask)
+                for i in 0..<a.count {
+                    out.append(a.mask[i] && a.data[i] ? 1 : 0)
+                }
+
+            case .string(let a):
+                out.append(SPBFormat.DTypeTag.string.rawValue)
+                // StringArray has no bitmap; derive one from the optionals.
+                appendBitmap(&out, BitVector(a.storage.map { $0 != nil }))
+                for i in 0..<a.count {
+                    if let value = a.storage[i] {
+                        let bytes = [UInt8](value.utf8)
+                        out.appendU32(UInt32(bytes.count))
+                        out.append(contentsOf: bytes)
+                    } else {
+                        out.appendU32(0)
+                    }
+                }
+
+            case .floatVector(let a):
+                out.append(SPBFormat.DTypeTag.floatVector.rawValue)
+                out.appendU32(UInt32(a.dims))
+                appendBitmap(&out, a.validity)
+                // Null rows are zero-filled by VectorArray's construction
+                // invariant, so the plane streams verbatim.
+                a.plane.withUnsafeBufferPointer { out.append(contentsOf: Data(buffer: $0)) }
+            }
+        }
+        return out
+    }
+
+    /// Write this frame to an SPB file. Byte-deterministic: two writes of
+    /// equal frames produce byte-identical files.
+    public func writeSPB(to url: URL) throws {
+        try toSPBData().write(to: url, options: .atomic)
+    }
+
+    /// Emit `ceil(rows/8)` bitmap bytes, LSB-first within each byte,
+    /// trailing bits zero (guaranteed by BitVector's tail-bit invariant).
+    private func appendBitmap(_ out: inout Data, _ bits: BitVector) {
+        let byteCount = SPBFormat.bitmapByteCount(rows: bits.bitCount)
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        for k in 0..<byteCount {
+            bytes[k] = UInt8(truncatingIfNeeded: bits.words[k / 8] >> ((k % 8) * 8))
+        }
+        out.append(contentsOf: bytes)
+    }
+}

--- a/Sources/SwiftPandas/Metal/MetalContext.swift
+++ b/Sources/SwiftPandas/Metal/MetalContext.swift
@@ -162,6 +162,10 @@ internal final class MetalContext: @unchecked Sendable {
     /// Pipeline for the `merge_hash_probe` kernel (Merge Phase 2: probe hash table with left table).
     let mergeHashProbePipeline: MTLComputePipelineState
 
+    /// Pipeline for the `swiftpandas_vector_batch_cosine` kernel (similarity
+    /// search: one thread per candidate row).
+    let vectorCosinePipeline: MTLComputePipelineState
+
     /// Private initializer — only called from the `shared` static closure.
     ///
     /// Creates all seven compute pipeline states eagerly. If any pipeline
@@ -199,6 +203,7 @@ internal final class MetalContext: @unchecked Sendable {
         self.groupByReduceCountPipeline = makePipeline("groupby_reduce_count")
         self.mergeHashBuildPipeline = makePipeline("merge_hash_build")
         self.mergeHashProbePipeline = makePipeline("merge_hash_probe")
+        self.vectorCosinePipeline = makePipeline("swiftpandas_vector_batch_cosine")
     }
 
     // MARK: - Buffer Helpers

--- a/Sources/SwiftPandas/Metal/MetalGroupBy.swift
+++ b/Sources/SwiftPandas/Metal/MetalGroupBy.swift
@@ -376,6 +376,11 @@ internal enum MetalGroupBy {
                 let (codes, uniques) = a.factorize()
                 let keys = (0..<uniques.count).map { "\(uniques[$0])" }
                 return (codes, keys)
+            case .floatVector:
+                // Vector group keys are rejected on the CPU path; returning
+                // the empty tuple makes the GPU aggregate bail out to that
+                // path (existing fallback philosophy).
+                return ([], [])
             default:
                 return ([], [])
             }

--- a/Sources/SwiftPandas/Metal/MetalShaders.swift
+++ b/Sources/SwiftPandas/Metal/MetalShaders.swift
@@ -159,7 +159,7 @@ internal enum MetalShaders {
     /// Combined MSL source for all shaders, formed by concatenating the
     /// common type definitions, GroupBy kernels, and Merge kernels into a
     /// single compilation unit.
-    static let allSource: String = commonTypes + groupByShaders + mergeShaders
+    static let allSource: String = commonTypes + groupByShaders + mergeShaders + vectorSearchShaders
 
     // MARK: - Common Types & Hashing
 
@@ -584,6 +584,47 @@ internal enum MetalShaders {
             // Hash collision (different key) — linear probe
             slot = (slot + 1) & mask;
         }
+    }
+    """
+
+    // MARK: - Vector Search Shaders
+
+    /// MSL source for the similarity-search batch-cosine kernel. Kept in
+    /// lockstep with `Shaders/VectorSearchShaders.metal` (the Xcode/metallib
+    /// twin) — edit both together.
+    static let vectorSearchShaders: String = """
+
+    // -----------------------------------------------------------------------
+    // Vector Search: Batch Cosine
+    // -----------------------------------------------------------------------
+    // One thread per candidate row of a compacted Float32 plane. Emits the
+    // raw cosine score per candidate; threshold/topK/tie-break always run on
+    // the CPU side (VectorSearchEngine), so ranking semantics live in one
+    // place. sqrt(|query|^2) is computed once on the CPU and passed in.
+    //
+    // The zero-denominator rule matches the CPU contract: score 0 when either
+    // norm is 0. Accumulation uses fma and may differ from vDSP at ulp level;
+    // bit-stability is only guaranteed by the CPU backend.
+    kernel void swiftpandas_vector_batch_cosine(
+        device const float* query    [[buffer(0)]],
+        device const float* plane    [[buffer(1)]],
+        device float* results        [[buffer(2)]],
+        constant uint& dims          [[buffer(3)]],
+        constant uint& count         [[buffer(4)]],
+        constant float& sqrt_nq      [[buffer(5)]],
+        uint tid [[thread_position_in_grid]])
+    {
+        if (tid >= count) return;
+        device const float* candidate = plane + (ulong)tid * (ulong)dims;
+        float dot = 0.0f;
+        float nc = 0.0f;
+        for (uint k = 0; k < dims; ++k) {
+            float v = candidate[k];
+            dot = fma(query[k], v, dot);
+            nc = fma(v, v, nc);
+        }
+        float denom = sqrt_nq * sqrt(nc);
+        results[tid] = (denom == 0.0f) ? 0.0f : (dot / denom);
     }
     """
 }

--- a/Sources/SwiftPandas/Metal/MetalVectorSearch.swift
+++ b/Sources/SwiftPandas/Metal/MetalVectorSearch.swift
@@ -1,0 +1,104 @@
+// ===----------------------------------------------------------------------===//
+//
+// MetalVectorSearch.swift
+// SwiftPandas
+//
+// GPU batch-cosine scoring for similarity search. This file owns only the
+// *mechanics* of GPU scoring (buffer setup, dispatch, readback); backend
+// *policy* — when to use the GPU, what to do when it is unusable — lives in
+// VectorSearchEngine, because backend selection is a search-semantics
+// decision.
+//
+// The GPU emits raw Float cosine scores only. Threshold, topK, and tie-break
+// always run on the shared CPU steps of the engine, so ranking semantics
+// exist in exactly one place. Scores may differ from the CPU backend at ulp
+// level (GPU fma accumulation order); bit-stability requires `.cpu`.
+//
+// When a mask/null filter excludes rows, the candidate plane is compacted on
+// the CPU before upload — mask-false rows never reach the GPU. When every row
+// is a candidate, the VectorArray's plane feeds the buffer directly (one
+// memcpy into shared memory via MetalContext.makeBuffer; no flattening pass).
+//
+// ===----------------------------------------------------------------------===//
+
+#if canImport(Metal)
+import Metal
+#endif
+
+internal enum MetalVectorSearch {
+    /// Human-readable reason the GPU path is unusable, for
+    /// `VectorError.metalUnavailable`.
+    static var unavailabilityReason: String {
+        if MetalDispatch.metalDisabled {
+            return "Metal disabled via SWIFTPANDAS_DISABLE_METAL"
+        }
+        #if canImport(Metal)
+        if MetalContext.shared == nil {
+            return "no Metal device/pipeline available on this host"
+        }
+        return "Metal buffer allocation failed"
+        #else
+        return "Metal is not supported on this platform"
+        #endif
+    }
+
+    /// Score cosine similarity of `query` against the candidate rows of
+    /// `array` on the GPU. Returns scores in candidate order (the CPU
+    /// zero-denominator rule is honored in-kernel), or `nil` when the GPU
+    /// path is unusable — callers decide whether nil is an error (`.metal`)
+    /// or a fallback (`.auto`).
+    static func scoreCosine(
+        _ array: VectorArray, query: [Float], candidates: [Int]
+    ) -> [Double]? {
+        #if canImport(Metal)
+        guard !MetalDispatch.metalDisabled, let context = MetalContext.shared else { return nil }
+        guard !candidates.isEmpty else { return [] }
+
+        let dims = array.dims
+        // sqrt(|q|²) once on the CPU, matching the CPU scorer's step order.
+        let sqrtNQ = query.withUnsafeBufferPointer { VectorOps.dotF($0, $0) }.squareRoot()
+
+        // Compact the candidate plane when rows are excluded; feed the raw
+        // plane directly when every row is a candidate.
+        let planeBuffer: MTLBuffer?
+        if candidates.count == array.count {
+            planeBuffer = context.makeBuffer(array.plane)
+        } else {
+            var compacted = [Float](repeating: 0, count: candidates.count * dims)
+            array.plane.withUnsafeBufferPointer { src in
+                compacted.withUnsafeMutableBufferPointer { dst in
+                    for (slot, row) in candidates.enumerated() {
+                        let s = row * dims
+                        let d = slot * dims
+                        for k in 0..<dims { dst[d + k] = src[s + k] }
+                    }
+                }
+            }
+            planeBuffer = context.makeBuffer(from: compacted)
+        }
+
+        guard
+            let plane = planeBuffer,
+            let queryBuffer = context.makeBuffer(from: query),
+            let resultsBuffer = context.makeBuffer(length: candidates.count * MemoryLayout<Float>.stride),
+            let dimsBuffer = context.makeBuffer(from: [UInt32(dims)]),
+            let countBuffer = context.makeBuffer(from: [UInt32(candidates.count)]),
+            let sqrtNQBuffer = context.makeBuffer(from: [sqrtNQ])
+        else { return nil }
+
+        context.dispatch(
+            pipeline: context.vectorCosinePipeline,
+            buffers: [
+                (queryBuffer, 0), (plane, 1), (resultsBuffer, 2),
+                (dimsBuffer, 3), (countBuffer, 4), (sqrtNQBuffer, 5),
+            ],
+            threadCount: candidates.count)
+
+        let raw = resultsBuffer.contents().bindMemory(
+            to: Float.self, capacity: candidates.count)
+        return (0..<candidates.count).map { Double(raw[$0]) }
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/SwiftPandas/Metal/Shaders/VectorSearchShaders.metal
+++ b/Sources/SwiftPandas/Metal/Shaders/VectorSearchShaders.metal
@@ -1,0 +1,34 @@
+// VectorSearchShaders.metal
+// SwiftPandas
+//
+// Xcode/metallib twin of MetalShaders.vectorSearchShaders (SPM builds compile
+// the embedded Swift string instead). Edit both together.
+
+#include <metal_stdlib>
+using namespace metal;
+
+// One thread per candidate row of a compacted Float32 plane. Emits the raw
+// cosine score per candidate; threshold/topK/tie-break run on the CPU side.
+// sqrt(|query|^2) is computed once on the CPU and passed in. Zero-denominator
+// rule matches the CPU contract: score 0 when either norm is 0.
+kernel void swiftpandas_vector_batch_cosine(
+    device const float* query    [[buffer(0)]],
+    device const float* plane    [[buffer(1)]],
+    device float* results        [[buffer(2)]],
+    constant uint& dims          [[buffer(3)]],
+    constant uint& count         [[buffer(4)]],
+    constant float& sqrt_nq      [[buffer(5)]],
+    uint tid [[thread_position_in_grid]])
+{
+    if (tid >= count) return;
+    device const float* candidate = plane + (ulong)tid * (ulong)dims;
+    float dot = 0.0f;
+    float nc = 0.0f;
+    for (uint k = 0; k < dims; ++k) {
+        float v = candidate[k];
+        dot = fma(query[k], v, dot);
+        nc = fma(v, v, nc);
+    }
+    float denom = sqrt_nq * sqrt(nc);
+    results[tid] = (denom == 0.0f) ? 0.0f : (dot / denom);
+}

--- a/Sources/SwiftPandas/Numeric/VectorOps.swift
+++ b/Sources/SwiftPandas/Numeric/VectorOps.swift
@@ -511,4 +511,60 @@ public enum VectorOps {
         _ = a.update(from: sorted)
         #endif
     }
+
+    // MARK: - Float32 kernels (vector columns)
+
+    /// Compute the Float32 dot product of two equal-length buffers.
+    ///
+    /// This is the primitive underlying the similarity-search bit-parity
+    /// contract: on Apple platforms it is exactly `vDSP_dotpr` — single
+    /// precision, vDSP's accumulation order, no widening. Consumers pin their
+    /// scores to this routine's bit pattern, so the Accelerate path MUST NOT
+    /// be replaced with a manually fused or reordered loop.
+    ///
+    /// **Scalar fallback** (non-Apple platforms): a plain in-order Float32
+    /// accumulation loop. Bit-parity with the vDSP path is *not* guaranteed
+    /// across platforms — the contract is per-platform.
+    public static func dotF(
+        _ a: UnsafeBufferPointer<Float>,
+        _ b: UnsafeBufferPointer<Float>
+    ) -> Float {
+        precondition(a.count == b.count)
+        guard a.count > 0 else { return 0 }
+        #if ACCELERATE_AVAILABLE
+        var result: Float = 0
+        vDSP_dotpr(a.baseAddress!, 1, b.baseAddress!, 1, &result, vDSP_Length(a.count))
+        return result
+        #else
+        var result: Float = 0
+        for i in 0..<a.count { result += a[i] * b[i] }
+        return result
+        #endif
+    }
+
+    /// Compute the Float32 squared Euclidean distance between two
+    /// equal-length buffers.
+    ///
+    /// **Accelerate path:** exactly `vDSP_distancesq` — part of the pinned
+    /// float-order for the euclidean metric (`Double(sqrt(distancesq))`).
+    /// **Scalar fallback:** in-order Float32 `(a-b)²` accumulation.
+    public static func distanceSqF(
+        _ a: UnsafeBufferPointer<Float>,
+        _ b: UnsafeBufferPointer<Float>
+    ) -> Float {
+        precondition(a.count == b.count)
+        guard a.count > 0 else { return 0 }
+        #if ACCELERATE_AVAILABLE
+        var result: Float = 0
+        vDSP_distancesq(a.baseAddress!, 1, b.baseAddress!, 1, &result, vDSP_Length(a.count))
+        return result
+        #else
+        var result: Float = 0
+        for i in 0..<a.count {
+            let d = a[i] - b[i]
+            result += d * d
+        }
+        return result
+        #endif
+    }
 }

--- a/Sources/SwiftPandas/Series/Series.swift
+++ b/Sources/SwiftPandas/Series/Series.swift
@@ -1388,6 +1388,15 @@ public struct Series: CustomStringConvertible, Sendable {
     ///
     /// - Returns: A ``Series`` of descriptive statistics.
     public func describe() -> Series {
+        if case .floatVector(let a) = data {
+            // Vector series report count / nulls / dims only — element-wise
+            // statistics are undefined for vector cells.
+            return Series(
+                data: .fromDoubles([Double(a.count), Double(a.count - a.validCount), Double(a.dims)]),
+                index: ["count", "nulls", "dims"],
+                name: name
+            )
+        }
         guard let doubles = data.asDouble() else {
             return Series(
                 data: .fromDoubles([Double(count), Double(validCount)]),

--- a/Sources/SwiftPandas/SwiftPandas.swift
+++ b/Sources/SwiftPandas/SwiftPandas.swift
@@ -40,5 +40,5 @@
 /// builds (`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`) used to produce XCFrameworks.
 public enum SwiftPandasInfo {
     /// The current semantic version of the SwiftPandas library.
-    public static let version = "0.7.0-beta"
+    public static let version = "0.8.0-beta"
 }

--- a/Sources/SwiftPandas/Vector/VectorArray.swift
+++ b/Sources/SwiftPandas/Vector/VectorArray.swift
@@ -1,0 +1,248 @@
+// ===----------------------------------------------------------------------===//
+//
+// VectorArray.swift
+// SwiftPandas
+//
+// Fixed-dimensionality Float32 vector storage for the `.floatVector` Column
+// case: a flat, contiguous, row-major plane plus an Arrow-style validity
+// bitmap. This one type owns every storage-layout decision for vector
+// columns — no other file may depend on the plane layout, the zero-fill rule,
+// or the norm cache.
+//
+// ## Invariants (established at construction, assumed everywhere else)
+//
+// - `dims >= 1`, immutable for the array's lifetime.
+// - `plane.count == count * dims` and `validity.bitCount == count`.
+// - A null row's plane slot is **zero-filled**. This is normative: it makes
+//   SPB file bytes deterministic (the writer streams the plane verbatim) and
+//   lets `Equatable` be synthesized safely.
+// - `squaredNorms[i]` is exactly `VectorOps.dotF(row_i, row_i)`, computed once
+//   at construction and *sliced* (never recomputed) by take/copy. The search
+//   bit-parity contract explicitly permits this cache: `vDSP_dotpr(v, v)` on
+//   the same bytes is bit-identical whenever computed. Null rows cache 0.
+// - The plane always holds **raw** vectors — normalization is an explicit,
+//   new-value operation only (see VectorSeriesOps.swift).
+//
+// ===----------------------------------------------------------------------===//
+
+/// Flat contiguous Float32 vector storage: `count` rows of `dims` elements
+/// each, with null support via a validity bitmap.
+public struct VectorArray: Sendable, Equatable {
+    /// Row-major plane of length `count * dims`. Null rows are zero-filled.
+    internal var plane: NativeArray<Float>
+    /// Validity bitmap: bit *i* set means row *i* holds a vector, cleared
+    /// means row *i* is null.
+    internal var validity: BitVector
+    /// The fixed dimensionality of every vector in this array.
+    public let dims: Int
+    /// Per-row cached squared L2 norm (`dotF(v, v)`); 0 for null rows.
+    internal var squaredNorms: NativeArray<Float>
+
+    // MARK: - Properties
+
+    /// The number of rows (including null rows).
+    public var count: Int { validity.bitCount }
+
+    /// The number of non-null rows.
+    public var validCount: Int { validity.popcount }
+
+    /// Total memory usage: plane + validity bitmap words + norm cache.
+    public var nbytes: Int {
+        plane.nbytes + validity.words.count * MemoryLayout<UInt64>.stride + squaredNorms.nbytes
+    }
+
+    // MARK: - Construction
+
+    /// Create from optional vectors; `nil` elements become null rows
+    /// (bitmap-cleared, zero-filled plane slot).
+    ///
+    /// - Throws: ``VectorError/invalidArgument(_:)`` if `dims < 1`;
+    ///   ``VectorError/dimensionMismatch(expected:got:)`` if any element's
+    ///   count differs from `dims`.
+    public init(vectors: [[Float]?], dims: Int) throws {
+        guard dims >= 1 else {
+            throw VectorError.invalidArgument("dims must be >= 1, got \(dims)")
+        }
+        var flat = ContiguousArray<Float>()
+        flat.reserveCapacity(vectors.count * dims)
+        var valid = [Bool]()
+        valid.reserveCapacity(vectors.count)
+        for vector in vectors {
+            if let vector = vector {
+                guard vector.count == dims else {
+                    throw VectorError.dimensionMismatch(expected: dims, got: vector.count)
+                }
+                flat.append(contentsOf: vector)
+                valid.append(true)
+            } else {
+                flat.append(contentsOf: repeatElement(0, count: dims))
+                valid.append(false)
+            }
+        }
+        self.init(plane: NativeArray(flat), validity: BitVector(valid), dims: dims)
+    }
+
+    /// Create from dense vectors (no nulls).
+    public init(vectors: [[Float]], dims: Int) throws {
+        guard dims >= 1 else {
+            throw VectorError.invalidArgument("dims must be >= 1, got \(dims)")
+        }
+        var flat = ContiguousArray<Float>()
+        flat.reserveCapacity(vectors.count * dims)
+        for vector in vectors {
+            guard vector.count == dims else {
+                throw VectorError.dimensionMismatch(expected: dims, got: vector.count)
+            }
+            flat.append(contentsOf: vector)
+        }
+        self.init(
+            plane: NativeArray(flat),
+            validity: BitVector(repeating: true, count: vectors.count),
+            dims: dims)
+    }
+
+    /// Internal init from pre-validated storage; computes the norm cache.
+    /// Callers must guarantee the invariants (dims >= 1, zero-filled nulls,
+    /// consistent lengths).
+    internal init(plane: NativeArray<Float>, validity: BitVector, dims: Int) {
+        precondition(dims >= 1, "VectorArray dims must be >= 1")
+        precondition(plane.count == validity.bitCount * dims,
+                     "VectorArray plane length \(plane.count) != rows \(validity.bitCount) * dims \(dims)")
+        self.plane = plane
+        self.validity = validity
+        self.dims = dims
+        self.squaredNorms = Self.computeSquaredNorms(plane: plane, dims: dims)
+    }
+
+    /// Internal init that carries a pre-sliced norm cache (take/copy paths).
+    internal init(
+        plane: NativeArray<Float>, validity: BitVector, dims: Int,
+        squaredNorms: NativeArray<Float>
+    ) {
+        precondition(plane.count == validity.bitCount * dims)
+        precondition(squaredNorms.count == validity.bitCount)
+        self.plane = plane
+        self.validity = validity
+        self.dims = dims
+        self.squaredNorms = squaredNorms
+    }
+
+    private static func computeSquaredNorms(plane: NativeArray<Float>, dims: Int) -> NativeArray<Float> {
+        let rows = plane.count / Swift.max(dims, 1)
+        guard rows > 0 else { return NativeArray(ContiguousArray<Float>()) }
+        var norms = ContiguousArray<Float>(repeating: 0, count: rows)
+        plane.withUnsafeBufferPointer { src in
+            norms.withUnsafeMutableBufferPointer { dst in
+                for row in 0..<rows {
+                    let slice = UnsafeBufferPointer(rebasing: src[(row * dims)..<((row + 1) * dims)])
+                    dst[row] = VectorOps.dotF(slice, slice)
+                }
+            }
+        }
+        return NativeArray(norms)
+    }
+
+    // MARK: - Row access
+
+    /// The vector at `row`, or `nil` for a null row. Copies.
+    public func row(_ index: Int) -> [Float]? {
+        precondition(index >= 0 && index < count, "Index \(index) out of range")
+        guard validity[index] else { return nil }
+        return plane.withUnsafeBufferPointer { src in
+            Array(src[(index * dims)..<((index + 1) * dims)])
+        }
+    }
+
+    /// NA mask: `true` at position *i* means row *i* is null.
+    public func isNA() -> [Bool] {
+        validity.boolArray.map { !$0 }
+    }
+
+    // MARK: - Take / copy / concat
+
+    /// Gather rows at the given positions. Out-of-range or negative indices
+    /// produce null rows, matching the other Column storage types.
+    public func take(indices: [Int]) -> VectorArray {
+        let n = count
+        var flat = ContiguousArray<Float>(repeating: 0, count: indices.count * dims)
+        var norms = ContiguousArray<Float>(repeating: 0, count: indices.count)
+        var valid = [Bool](repeating: false, count: indices.count)
+        plane.withUnsafeBufferPointer { src in
+            squaredNorms.withUnsafeBufferPointer { srcNorms in
+                flat.withUnsafeMutableBufferPointer { dst in
+                    for (j, i) in indices.enumerated() where i >= 0 && i < n && validity[i] {
+                        let s = i * dims
+                        let d = j * dims
+                        for k in 0..<dims { dst[d + k] = src[s + k] }
+                        norms[j] = srcNorms[i]
+                        valid[j] = true
+                    }
+                }
+            }
+        }
+        return VectorArray(
+            plane: NativeArray(flat), validity: BitVector(valid), dims: dims,
+            squaredNorms: NativeArray(norms))
+    }
+
+    /// Gather rows where `mask` is true. `trueCount` must equal the number of
+    /// true entries (same contract as the other storage types).
+    public func take(mask: [Bool], trueCount: Int) -> VectorArray {
+        precondition(mask.count == count, "Mask length \(mask.count) != row count \(count)")
+        var flat = ContiguousArray<Float>(repeating: 0, count: trueCount * dims)
+        var norms = ContiguousArray<Float>(repeating: 0, count: trueCount)
+        var valid = [Bool](repeating: false, count: trueCount)
+        plane.withUnsafeBufferPointer { src in
+            squaredNorms.withUnsafeBufferPointer { srcNorms in
+                flat.withUnsafeMutableBufferPointer { dst in
+                    var j = 0
+                    for i in 0..<mask.count where mask[i] {
+                        if validity[i] {
+                            let s = i * dims
+                            let d = j * dims
+                            for k in 0..<dims { dst[d + k] = src[s + k] }
+                            norms[j] = srcNorms[i]
+                            valid[j] = true
+                        }
+                        j += 1
+                    }
+                }
+            }
+        }
+        return VectorArray(
+            plane: NativeArray(flat), validity: BitVector(valid), dims: dims,
+            squaredNorms: NativeArray(norms))
+    }
+
+    /// Deep, independent copy.
+    public func copy() -> VectorArray {
+        VectorArray(
+            plane: NativeArray(ContiguousArray(plane.array)),
+            validity: validity,
+            dims: dims,
+            squaredNorms: NativeArray(ContiguousArray(squaredNorms.array)))
+    }
+
+    /// Concatenate arrays end to end.
+    ///
+    /// - Throws: ``VectorError/dimensionMismatch(expected:got:)`` if the
+    ///   arrays do not all share the same `dims`.
+    public static func concat(_ arrays: [VectorArray]) throws -> VectorArray {
+        guard let first = arrays.first else {
+            return VectorArray(plane: NativeArray(ContiguousArray<Float>()),
+                               validity: BitVector(repeating: true, count: 0), dims: 1)
+        }
+        for array in arrays.dropFirst() where array.dims != first.dims {
+            throw VectorError.dimensionMismatch(expected: first.dims, got: array.dims)
+        }
+        var plane = first.plane
+        var norms = first.squaredNorms
+        var validity = first.validity
+        for array in arrays.dropFirst() {
+            plane.append(contentsOf: array.plane)
+            norms.append(contentsOf: array.squaredNorms)
+            validity.append(contentsOf: array.validity)
+        }
+        return VectorArray(plane: plane, validity: validity, dims: first.dims, squaredNorms: norms)
+    }
+}

--- a/Sources/SwiftPandas/Vector/VectorError.swift
+++ b/Sources/SwiftPandas/Vector/VectorError.swift
@@ -1,0 +1,59 @@
+// ===----------------------------------------------------------------------===//
+//
+// VectorError.swift
+// SwiftPandas
+//
+// Typed errors for the vector column type, similarity search, and SPB binary
+// IO. Every misuse of the vector API throws one of these cases with a
+// human-readable description — nothing returns an empty result on invalid
+// input.
+//
+// Boundary with ``DataFrameError``: frame-shape problems (e.g. a missing
+// column name passed to `similaritySearch(on:)`) keep throwing
+// ``DataFrameError`` for consistency with every other column-resolving API;
+// vector-semantics problems throw ``VectorError``.
+//
+// ===----------------------------------------------------------------===//
+
+/// Errors thrown by vector column construction, similarity search, and SPB IO.
+public enum VectorError: Error, CustomStringConvertible, Sendable {
+    /// A vector's element count does not match the required dimensionality.
+    case dimensionMismatch(expected: Int, got: Int)
+    /// A candidate mask's length does not match the frame's row count.
+    case maskLengthMismatch(expected: Int, got: Int)
+    /// The requested operation is not supported for the given dtype.
+    case unsupportedOperation(op: String, dtype: String)
+    /// The `.metal` backend was requested but the device/pipeline is unusable.
+    case metalUnavailable(String)
+    /// The `.metal` backend was requested with a metric the GPU does not
+    /// support (GPU is cosine-only in v1).
+    case metalUnsupportedMetric(DistanceMetric)
+    /// An SPB file failed validation. The reason is human-readable.
+    case corrupt(reason: String)
+    /// An SPB file declares a format version newer than this library supports.
+    case versionUnsupported(found: UInt32, supported: UInt32)
+    /// A caller-supplied argument is invalid (topK <= 0, dims < 1, empty
+    /// query, ...).
+    case invalidArgument(String)
+
+    public var description: String {
+        switch self {
+        case .dimensionMismatch(let expected, let got):
+            return "dimension mismatch: expected \(expected), got \(got)"
+        case .maskLengthMismatch(let expected, let got):
+            return "mask length mismatch: expected \(expected) (row count), got \(got)"
+        case .unsupportedOperation(let op, let dtype):
+            return "unsupported operation '\(op)' for dtype \(dtype)"
+        case .metalUnavailable(let reason):
+            return "Metal backend unavailable: \(reason)"
+        case .metalUnsupportedMetric(let metric):
+            return "Metal backend does not support metric '\(metric.rawValue)' (cosine only)"
+        case .corrupt(let reason):
+            return "corrupt SPB data: \(reason)"
+        case .versionUnsupported(let found, let supported):
+            return "unsupported SPB format version \(found) (this library supports <= \(supported))"
+        case .invalidArgument(let reason):
+            return "invalid argument: \(reason)"
+        }
+    }
+}

--- a/Sources/SwiftPandas/Vector/VectorSearch.swift
+++ b/Sources/SwiftPandas/Vector/VectorSearch.swift
@@ -1,0 +1,300 @@
+// ===----------------------------------------------------------------------===//
+//
+// VectorSearch.swift
+// SwiftPandas
+//
+// Similarity search over `.floatVector` columns: public options/result types,
+// the DataFrame facade, and the internal engine that owns the one ordering of
+// search decisions:
+//
+//     candidate compaction -> scoring -> threshold -> top-K -> tie-break
+//
+// The engine is the single implementation for every backend: the GPU (M4)
+// produces raw scores only, so null/mask exclusion and ranking semantics can
+// never diverge between backends.
+//
+// ## Numeric contract (normative, CPU backend — do not "optimize")
+//
+// Consumers pin bit-identical scores on the CPU backend. Cosine is computed,
+// exactly, in Float32 order:
+//
+//   1. dot   = vDSP_dotpr(query, candidate)                      (Float)
+//   2. nQ    = vDSP_dotpr(query, query)     — once per query     (Float)
+//      nC    = squaredNorms[row]            — construction cache (Float;
+//              bit-identical to on-the-fly vDSP_dotpr(v, v) by contract)
+//   3. denom = sqrt(nQ) * sqrt(nC)          (Float sqrts, Float multiply)
+//   4. denom == 0  ->  score = 0.0 (Double)
+//      else           score = Double(dot / denom)  (Float divide, then widen)
+//
+// Dot:       score = Double(vDSP_dotpr(q, c))
+// Euclidean: score = Double(sqrt(vDSP_distancesq(q, c)))  (Float sqrt, widen)
+//
+// No Double accumulation, no fused rearrangement, no epsilon guards. Bit
+// determinism (same input -> same bytes, every run) is normative for the CPU
+// backend on Apple platforms; non-Apple builds use VectorOps' scalar
+// fallbacks, so the pin is per-platform.
+//
+// ===----------------------------------------------------------------------===//
+
+/// Options for ``DataFrame/similaritySearch(on:query:options:)``.
+public struct SearchOptions: Sendable {
+    /// The scoring metric. Defaults to cosine.
+    public var metric: DistanceMetric = .cosine
+    /// Number of results to keep after threshold filtering. `topK <= 0`
+    /// throws ``VectorError/invalidArgument(_:)``.
+    public var topK: Int = 10
+    /// Optional score cutoff. cosine/dot: keep `score >= threshold`;
+    /// euclidean: keep `distance <= threshold`.
+    public var threshold: Double? = nil
+    /// Optional candidate pre-filter; length must equal the frame's row count
+    /// (else ``VectorError/maskLengthMismatch(expected:got:)``). Mask-false
+    /// rows are excluded before scoring.
+    public var mask: [Bool]? = nil
+    /// Which compute backend scores candidates. Defaults to CPU — the
+    /// documented primary and the bit-stable path.
+    public var backend: SearchBackend = .cpu
+    public init() {}
+}
+
+/// Compute backend for candidate scoring.
+public enum SearchBackend: Sendable {
+    /// vDSP brute force — always available; the documented primary and the
+    /// only bit-stable path.
+    case cpu
+    /// GPU batch scoring (cosine-only in v1). Throws when unusable — never
+    /// falls back silently.
+    case metal
+    /// Uses metal iff post-mask candidate count exceeds `gpuThreshold` AND
+    /// the pipeline is available; otherwise cpu. The decision is observable
+    /// via ``SearchResultFrame/backendUsed``.
+    case auto(gpuThreshold: Int = 16_384)
+}
+
+/// The result of a similarity search: matching rows of the source frame with
+/// their scores, ranked best-first.
+public struct SearchResultFrame: Sendable {
+    /// Matching rows of the source frame (original columns) plus a
+    /// `"__score"` Double column, ranked best-first.
+    public let frame: DataFrame
+    /// `"cpu-vdsp"` or `"metal"` — which backend actually scored. Never
+    /// silent: `.auto` decisions are observable here.
+    public let backendUsed: String
+}
+
+// MARK: - Engine
+
+/// Internal single implementation of search semantics. Public facades and
+/// (in M4) the Metal scorer all route through here.
+enum VectorSearchEngine {
+    struct Hits {
+        let rowIndices: [Int]
+        let scores: [Double]
+        let backendUsed: String
+    }
+
+    static let scoreColumnName = "__score"
+    static let cpuBackendName = "cpu-vdsp"
+    static let metalBackendName = "metal"
+
+    static func search(
+        _ array: VectorArray, query: [Float], options: SearchOptions, rowCount: Int
+    ) throws -> Hits {
+        // --- Validation (nothing returns an empty result on invalid input) ---
+        guard options.topK > 0 else {
+            throw VectorError.invalidArgument("topK must be > 0, got \(options.topK)")
+        }
+        guard !query.isEmpty else {
+            throw VectorError.invalidArgument("query vector is empty")
+        }
+        guard query.count == array.dims else {
+            throw VectorError.dimensionMismatch(expected: array.dims, got: query.count)
+        }
+        if let mask = options.mask, mask.count != rowCount {
+            throw VectorError.maskLengthMismatch(expected: rowCount, got: mask.count)
+        }
+
+        // --- 1. Compact candidates once (bitmap-valid AND mask-true). Both
+        //        CPU and GPU paths consume this one list, so null/mask
+        //        exclusion cannot diverge between backends. ---
+        var candidates = [Int]()
+        candidates.reserveCapacity(array.count)
+        if let mask = options.mask {
+            for row in 0..<array.count where mask[row] && array.validity[row] {
+                candidates.append(row)
+            }
+        } else if array.validity.allValid {
+            candidates = Array(0..<array.count)
+        } else {
+            for row in 0..<array.count where array.validity[row] {
+                candidates.append(row)
+            }
+        }
+
+        // --- 2. Score (backend selection) ---
+        let scores: [Double]
+        let backendUsed: String
+        switch options.backend {
+        case .cpu:
+            scores = scoreCPU(array, query: query, candidates: candidates, metric: options.metric)
+            backendUsed = cpuBackendName
+        case .metal:
+            scores = try scoreMetalOrThrow(
+                array, query: query, candidates: candidates, metric: options.metric)
+            backendUsed = metalBackendName
+        case .auto(let gpuThreshold):
+            if options.metric == .cosine,
+               candidates.count > gpuThreshold,
+               let gpuScores = MetalVectorSearch.scoreCosine(
+                   array, query: query, candidates: candidates) {
+                scores = gpuScores
+                backendUsed = metalBackendName
+            } else {
+                scores = scoreCPU(array, query: query, candidates: candidates, metric: options.metric)
+                backendUsed = cpuBackendName
+            }
+        }
+
+        // --- 3. Threshold filter (metric direction) ---
+        var survivors = [(row: Int, score: Double)]()
+        survivors.reserveCapacity(candidates.count)
+        if let threshold = options.threshold {
+            switch options.metric {
+            case .cosine, .dot:
+                for i in 0..<candidates.count where scores[i] >= threshold {
+                    survivors.append((candidates[i], scores[i]))
+                }
+            case .euclidean:
+                for i in 0..<candidates.count where scores[i] <= threshold {
+                    survivors.append((candidates[i], scores[i]))
+                }
+            }
+        } else {
+            for i in 0..<candidates.count {
+                survivors.append((candidates[i], scores[i]))
+            }
+        }
+
+        // --- 4. Deterministic ranking: primary by score in metric direction,
+        //        tie-break by source row index ascending. topK truncates
+        //        after threshold filtering. ---
+        let higherIsBetter = options.metric != .euclidean
+        survivors.sort { a, b in
+            if a.score != b.score {
+                return higherIsBetter ? a.score > b.score : a.score < b.score
+            }
+            return a.row < b.row
+        }
+        let top = survivors.prefix(options.topK)
+        return Hits(
+            rowIndices: top.map { $0.row },
+            scores: top.map { $0.score },
+            backendUsed: backendUsed)
+    }
+
+    // MARK: CPU scorer (the bit-parity path — see file header contract)
+
+    private static func scoreCPU(
+        _ array: VectorArray, query: [Float], candidates: [Int], metric: DistanceMetric
+    ) -> [Double] {
+        let dims = array.dims
+        var scores = [Double](repeating: 0, count: candidates.count)
+        query.withUnsafeBufferPointer { q in
+            array.plane.withUnsafeBufferPointer { plane in
+                switch metric {
+                case .cosine:
+                    let nQ = VectorOps.dotF(q, q)
+                    let sqrtNQ = nQ.squareRoot()
+                    array.squaredNorms.withUnsafeBufferPointer { norms in
+                        for (i, row) in candidates.enumerated() {
+                            let candidate = UnsafeBufferPointer(
+                                rebasing: plane[(row * dims)..<((row + 1) * dims)])
+                            let dot = VectorOps.dotF(q, candidate)
+                            let denom = sqrtNQ * norms[row].squareRoot()
+                            scores[i] = denom == 0 ? 0.0 : Double(dot / denom)
+                        }
+                    }
+                case .dot:
+                    for (i, row) in candidates.enumerated() {
+                        let candidate = UnsafeBufferPointer(
+                            rebasing: plane[(row * dims)..<((row + 1) * dims)])
+                        scores[i] = Double(VectorOps.dotF(q, candidate))
+                    }
+                case .euclidean:
+                    for (i, row) in candidates.enumerated() {
+                        let candidate = UnsafeBufferPointer(
+                            rebasing: plane[(row * dims)..<((row + 1) * dims)])
+                        scores[i] = Double(VectorOps.distanceSqF(q, candidate).squareRoot())
+                    }
+                }
+            }
+        }
+        return scores
+    }
+
+    // MARK: Metal (strict `.metal` policy; scorer lands in M4)
+
+    private static func scoreMetalOrThrow(
+        _ array: VectorArray, query: [Float], candidates: [Int], metric: DistanceMetric
+    ) throws -> [Double] {
+        guard metric == .cosine else {
+            throw VectorError.metalUnsupportedMetric(metric)
+        }
+        guard let scores = MetalVectorSearch.scoreCosine(
+            array, query: query, candidates: candidates) else {
+            throw VectorError.metalUnavailable(MetalVectorSearch.unavailabilityReason)
+        }
+        return scores
+    }
+}
+
+// MARK: - DataFrame facade
+
+extension DataFrame {
+    /// Top-K similarity search over a `.floatVector` column.
+    ///
+    /// Null vector rows and mask-false rows are excluded before scoring.
+    /// Ranking is fully deterministic: primary by score (metric direction),
+    /// ties broken by source row index ascending.
+    ///
+    /// - Parameters:
+    ///   - column: Name of a `.floatVector` column.
+    ///   - query: The query vector; its count must equal the column's dims.
+    ///   - options: Metric, topK, threshold, mask, and backend.
+    /// - Returns: Matching rows plus a `"__score"` Double column, best-first,
+    ///   and the backend that actually scored.
+    /// - Throws: ``DataFrameError/columnNotFound(_:)`` for a missing column;
+    ///   ``VectorError`` for every vector-semantics misuse.
+    public func similaritySearch(
+        on column: String, query: [Float], options: SearchOptions = .init()
+    ) throws -> SearchResultFrame {
+        guard let col = columns[column] else {
+            throw DataFrameError.columnNotFound(column)
+        }
+        guard case .floatVector(let array) = col else {
+            throw VectorError.unsupportedOperation(
+                op: "similaritySearch", dtype: col.dtype.description)
+        }
+        let hits = try VectorSearchEngine.search(
+            array, query: query, options: options, rowCount: rowCount)
+        var frame = takeRows(hits.rowIndices)
+        frame[VectorSearchEngine.scoreColumnName] = Series(
+            data: .fromDoubles(hits.scores), name: VectorSearchEngine.scoreColumnName)
+        return SearchResultFrame(frame: frame, backendUsed: hits.backendUsed)
+    }
+
+    /// Batch form of ``similaritySearch(on:query:options:)``.
+    ///
+    /// Semantically identical to N sequential calls (executed sequentially in
+    /// order, so the identity holds by construction); per-query results are
+    /// order-stable.
+    public func similaritySearchBatch(
+        on column: String, queries: [[Float]], options: SearchOptions = .init()
+    ) throws -> [SearchResultFrame] {
+        var results = [SearchResultFrame]()
+        results.reserveCapacity(queries.count)
+        for query in queries {
+            results.append(try similaritySearch(on: column, query: query, options: options))
+        }
+        return results
+    }
+}

--- a/Sources/SwiftPandas/Vector/VectorSeriesOps.swift
+++ b/Sources/SwiftPandas/Vector/VectorSeriesOps.swift
@@ -1,0 +1,126 @@
+// ===----------------------------------------------------------------------===//
+//
+// VectorSeriesOps.swift
+// SwiftPandas
+//
+// Distance metrics and Series-level vector operations (norms, normalization)
+// for `.floatVector` columns.
+//
+// Storage invariant (cross-module, normative): a ``VectorArray`` always holds
+// **raw** vectors. Normalization is only ever an explicit, new-value operation
+// (``Series/normalizedL2()``) — never applied implicitly by construction, IO,
+// or search. This is the premise of the search bit-parity contract: all three
+// metrics score from one raw plane.
+//
+// ===----------------------------------------------------------------------===//
+
+/// The similarity/distance metric used by ``DataFrame/similaritySearch(on:query:options:)``.
+public enum DistanceMetric: String, Sendable, Codable, CaseIterable {
+    /// Cosine similarity: `dot / (|a||b|)`. Higher is better; range [-1, 1];
+    /// defined as 0 when either norm is 0.
+    case cosine
+    /// Dot product. Higher is better.
+    case dot
+    /// Euclidean (L2) distance. **Lower** is better.
+    case euclidean
+}
+
+// MARK: - Series construction & access
+
+public extension Series {
+    /// Create a Series backed by a `.floatVector` column.
+    ///
+    /// - Throws: ``VectorError/dimensionMismatch(expected:got:)`` /
+    ///   ``VectorError/invalidArgument(_:)`` per ``Column/fromVectors(_:dims:)``.
+    init(vectors: [[Float]], dims: Int, name: String) throws {
+        self.init(data: try .fromVectors(vectors, dims: dims), name: name)
+    }
+}
+
+extension Series {
+    /// The dimensionality of this series' vectors, or `nil` for non-vector
+    /// series. This is the safe probe for "is this a vector series?".
+    public var vectorDims: Int? {
+        if case .floatVector(let a) = data { return a.dims }
+        return nil
+    }
+
+    private func requireVectorArray(op: String) -> VectorArray {
+        guard case .floatVector(let a) = data else {
+            preconditionFailure(
+                "\(op) is only valid on floatVector series (got \(data.dtype)); "
+                + "probe with vectorDims first")
+        }
+        return a
+    }
+
+    /// The vector at `row`, or `nil` for a null row. Copies.
+    ///
+    /// Only valid on floatVector series (precondition failure otherwise —
+    /// this non-throwing accessor mirrors the subscript conventions of the
+    /// library; use ``vectorDims`` to probe).
+    public func vector(at row: Int) -> [Float]? {
+        requireVectorArray(op: "vector(at:)").row(row)
+    }
+
+    /// All vectors, null rows as `nil`. Copies.
+    public func vectors() -> [[Float]?] {
+        let array = requireVectorArray(op: "vectors()")
+        return (0..<array.count).map { array.row($0) }
+    }
+
+    /// Zero-copy access to the raw row-major plane for compute kernels. The
+    /// body receives the full plane (`count * dims` floats) and the dims; no
+    /// copy is allocated.
+    public func withUnsafeVectorPlane<R>(
+        _ body: (UnsafeBufferPointer<Float>, _ dims: Int) throws -> R
+    ) rethrows -> R {
+        let array = requireVectorArray(op: "withUnsafeVectorPlane")
+        return try array.plane.withUnsafeBufferPointer { try body($0, array.dims) }
+    }
+
+    /// Per-row L2 norms (`sqrt` of the construction-time cached squared
+    /// norms); null rows report 0.
+    ///
+    /// - Throws: ``VectorError/unsupportedOperation(op:dtype:)`` on
+    ///   non-vector series.
+    public func l2Norms() throws -> [Float] {
+        guard case .floatVector(let array) = data else {
+            throw VectorError.unsupportedOperation(op: "l2Norms", dtype: data.dtype.description)
+        }
+        return array.squaredNorms.withUnsafeBufferPointer { norms in
+            norms.map { $0.squareRoot() }
+        }
+    }
+
+    /// A new series whose vectors are L2-normalized (unit length). Zero-norm
+    /// rows stay zero vectors; null rows stay null.
+    ///
+    /// This is the **only** normalizer in the library — storage always holds
+    /// raw vectors, and construction/IO/search never normalize implicitly.
+    ///
+    /// - Throws: ``VectorError/unsupportedOperation(op:dtype:)`` on
+    ///   non-vector series.
+    public func normalizedL2() throws -> Series {
+        guard case .floatVector(let array) = data else {
+            throw VectorError.unsupportedOperation(op: "normalizedL2", dtype: data.dtype.description)
+        }
+        let dims = array.dims
+        var normalized = ContiguousArray<Float>(repeating: 0, count: array.plane.count)
+        array.plane.withUnsafeBufferPointer { src in
+            array.squaredNorms.withUnsafeBufferPointer { norms in
+                normalized.withUnsafeMutableBufferPointer { dst in
+                    for row in 0..<array.count {
+                        let norm = norms[row].squareRoot()
+                        guard norm != 0 else { continue }  // zero vectors (and nulls) stay zero
+                        let base = row * dims
+                        for k in 0..<dims { dst[base + k] = src[base + k] / norm }
+                    }
+                }
+            }
+        }
+        let result = VectorArray(
+            plane: NativeArray(normalized), validity: array.validity, dims: dims)
+        return Series(data: .floatVector(result), name: name)
+    }
+}

--- a/Tests/SwiftPandasTests/BenchmarkTests.swift
+++ b/Tests/SwiftPandasTests/BenchmarkTests.swift
@@ -747,6 +747,67 @@ final class BenchmarkTests: XCTestCase {
 
     // ─── Summary ────────────────────────────────────────────────────────
 
+    // ─── 13. Vector Search (R8 performance contract) ────────────────────
+
+    /// Benchmarks the vector column workload sized to the primary consumer
+    /// contract: 100K rows x 1024 dims Float32 (~400 MB plane).
+    ///
+    /// R8 indicative targets (Apple Silicon M2-class): cosine topK=10 CPU
+    /// <= 150 ms; Metal (incl. transfer) <= 30 ms; fromVectors <= 500 ms;
+    /// writeSPB/readSPB <= 2 s each.
+    func testVA_VectorSearch() throws {
+        BenchmarkTests.section("13", "Vector Search (100,000 x 1024 dims Float32)")
+
+        let rows = 100_000
+        let dims = 1024
+        var rng = BenchmarkTests.LCG()
+        var vectors = [[Float]]()
+        vectors.reserveCapacity(rows)
+        for _ in 0..<rows {
+            vectors.append((0..<dims).map { _ in Float(rng.next()) - 0.5 })
+        }
+
+        BenchmarkTests.tableHeader()
+
+        var column: Column! = nil
+        let tConstruct = BenchmarkTests.benchmark(1) {
+            column = try! Column.fromVectors(vectors, dims: dims)
+        }
+        BenchmarkTests.benchRow("fromVectors 100Kx1024", ns: tConstruct)
+
+        let df = DataFrame(columns: [
+            ("id", .fromInts(Array(0..<rows))),
+            ("embedding", column),
+        ])
+        let query = vectors[500]
+
+        let tCosine = BenchmarkTests.benchmark {
+            _ = try! df.similaritySearch(on: "embedding", query: query)
+        }
+        BenchmarkTests.benchRow("cosine topK=10 (cpu-vdsp)", ns: tCosine)
+
+        if MetalDispatch.isAvailable {
+            var gpuOptions = SearchOptions()
+            gpuOptions.backend = .metal
+            let tMetal = BenchmarkTests.benchmark {
+                _ = try! df.similaritySearch(on: "embedding", query: query, options: gpuOptions)
+            }
+            BenchmarkTests.benchRow("cosine topK=10 (metal)", ns: tMetal)
+        }
+
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("spb_bench_\(UUID().uuidString).spb")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let tWrite = BenchmarkTests.benchmark(1) {
+            try! df.writeSPB(to: url)
+        }
+        BenchmarkTests.benchRow("writeSPB (~400 MB)", ns: tWrite)
+        let tRead = BenchmarkTests.benchmark(1) {
+            _ = try! DataFrame.readSPB(from: url)
+        }
+        BenchmarkTests.benchRow("readSPB (~400 MB)", ns: tRead)
+    }
+
     /// Prints a summary of all optimizations applied by SwiftPandas and Metal GPU details.
     /// Runs last due to the `ZZ` prefix.
     func testZZ_BenchmarkSummary() {

--- a/Tests/SwiftPandasTests/MetalVectorSearchTests.swift
+++ b/Tests/SwiftPandasTests/MetalVectorSearchTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import SwiftPandas
+
+/// A3 acceptance: CPU↔Metal score parity (≤ 1e-5, identical ranking) on
+/// seeded-random data, the strict `.metal` throw policy, and `.auto`
+/// observability via `backendUsed`.
+final class MetalVectorSearchTests: XCTestCase {
+
+    /// Deterministic LCG-seeded vectors (same convention as BenchmarkTests).
+    private func seededVectors(count: Int, dims: Int, seed: UInt64 = 42) -> [[Float]] {
+        var state = seed
+        var vectors = [[Float]]()
+        vectors.reserveCapacity(count)
+        for _ in 0..<count {
+            var v = [Float](repeating: 0, count: dims)
+            for k in 0..<dims {
+                state = state &* 6364136223846793005 &+ 1442695040888963407
+                v[k] = Float(state >> 40) / Float(1 << 24) - 0.5
+            }
+            vectors.append(v)
+        }
+        return vectors
+    }
+
+    private func scores(_ result: SearchResultFrame) -> [Double] {
+        guard case .double(let a) = result.frame["__score"].data else { return [] }
+        return (0..<a.count).map { a[$0]! }
+    }
+
+    private func ids(_ result: SearchResultFrame) -> [Int64] {
+        guard case .int64(let a) = result.frame["id"].data else { return [] }
+        return (0..<a.count).map { a[$0]! }
+    }
+
+    // MARK: - A3 parity
+
+    func test_cpuMetalParity_10Kx512_seededRandom() throws {
+        guard MetalDispatch.isAvailable else {
+            throw XCTSkip("No Metal device on this host; the throw policy is covered by test_metalBackend_whenDisabled_throwsMetalUnavailable")
+        }
+        let vectors = seededVectors(count: 10_000, dims: 512)
+        let df = DataFrame(columns: [
+            ("id", .fromInts(Array(0..<vectors.count))),
+            ("embedding", try .fromVectors(vectors, dims: 512)),
+        ])
+        var cpuOptions = SearchOptions()
+        cpuOptions.topK = 100
+        var gpuOptions = cpuOptions
+        gpuOptions.backend = .metal
+
+        let query = vectors[123]
+        let cpu = try df.similaritySearch(on: "embedding", query: query, options: cpuOptions)
+        let gpu = try df.similaritySearch(on: "embedding", query: query, options: gpuOptions)
+
+        XCTAssertEqual(cpu.backendUsed, "cpu-vdsp")
+        XCTAssertEqual(gpu.backendUsed, "metal")
+        // Identical ranking on non-degenerate data.
+        XCTAssertEqual(ids(cpu), ids(gpu))
+        // Scores within 1e-5 absolute (GPU fma order differs at ulp level).
+        for (c, g) in zip(scores(cpu), scores(gpu)) {
+            XCTAssertEqual(c, g, accuracy: 1e-5)
+        }
+    }
+
+    func test_metalHonorsMaskAndNulls() throws {
+        guard MetalDispatch.isAvailable else {
+            throw XCTSkip("No Metal device on this host")
+        }
+        var optionals: [[Float]?] = seededVectors(count: 64, dims: 16)
+        optionals[3] = nil
+        optionals[40] = nil
+        let df = DataFrame(columns: [
+            ("id", .fromInts(Array(0..<optionals.count))),
+            ("embedding", try .fromOptionalVectors(optionals, dims: 16)),
+        ])
+        var mask = [Bool](repeating: true, count: 64)
+        for i in 0..<32 { mask[i] = false }
+
+        var cpuOptions = SearchOptions()
+        cpuOptions.topK = 64
+        cpuOptions.mask = mask
+        var gpuOptions = cpuOptions
+        gpuOptions.backend = .metal
+
+        let query = optionals[33]!
+        let cpu = try df.similaritySearch(on: "embedding", query: query, options: cpuOptions)
+        let gpu = try df.similaritySearch(on: "embedding", query: query, options: gpuOptions)
+        XCTAssertEqual(ids(cpu), ids(gpu))
+        XCTAssertFalse(ids(gpu).contains(40))  // null row excluded
+        XCTAssertTrue(ids(gpu).allSatisfy { $0 >= 32 })  // mask honored
+    }
+
+    // MARK: - Strict `.metal` policy
+
+    func test_metalBackend_whenDisabled_throwsMetalUnavailable() throws {
+        // Force-disable so this assertion runs on GPU hosts too — the throw
+        // policy must be asserted, never skipped silently (A3).
+        let saved = MetalDispatch.metalDisabled
+        MetalDispatch.metalDisabled = true
+        defer { MetalDispatch.metalDisabled = saved }
+
+        let df = DataFrame(columns: [
+            ("embedding", try .fromVectors([[1, 0]], dims: 2)),
+        ])
+        var options = SearchOptions()
+        options.backend = .metal
+        XCTAssertThrowsError(
+            try df.similaritySearch(on: "embedding", query: [1, 0], options: options)) { error in
+            guard case VectorError.metalUnavailable(let reason) = error else {
+                return XCTFail("expected metalUnavailable, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("SWIFTPANDAS_DISABLE_METAL"))
+        }
+    }
+
+    func test_metalBackend_nonCosineMetric_throwsUnsupportedMetric() throws {
+        let df = DataFrame(columns: [
+            ("embedding", try .fromVectors([[1, 0]], dims: 2)),
+        ])
+        for metric in [DistanceMetric.dot, .euclidean] {
+            var options = SearchOptions()
+            options.backend = .metal
+            options.metric = metric
+            XCTAssertThrowsError(
+                try df.similaritySearch(on: "embedding", query: [1, 0], options: options)) { error in
+                guard case VectorError.metalUnsupportedMetric(let m) = error else {
+                    return XCTFail("expected metalUnsupportedMetric, got \(error)")
+                }
+                XCTAssertEqual(m, metric)
+            }
+        }
+    }
+
+    // MARK: - `.auto` observability
+
+    func test_autoBackend_belowThreshold_usesCPU() throws {
+        let df = DataFrame(columns: [
+            ("embedding", try .fromVectors([[1, 0], [0, 1]], dims: 2)),
+        ])
+        var options = SearchOptions()
+        options.backend = .auto(gpuThreshold: 16_384)
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0], options: options)
+        XCTAssertEqual(result.backendUsed, "cpu-vdsp")
+    }
+
+    func test_autoBackend_aboveThreshold_usesMetalWhenAvailable() throws {
+        let vectors = seededVectors(count: 512, dims: 32)
+        let df = DataFrame(columns: [
+            ("id", .fromInts(Array(0..<vectors.count))),
+            ("embedding", try .fromVectors(vectors, dims: 32)),
+        ])
+        var options = SearchOptions()
+        options.backend = .auto(gpuThreshold: 256)  // 512 candidates > 256
+        let result = try df.similaritySearch(on: "embedding", query: vectors[0], options: options)
+        if MetalDispatch.isAvailable {
+            XCTAssertEqual(result.backendUsed, "metal")
+        } else {
+            XCTAssertEqual(result.backendUsed, "cpu-vdsp")  // observable fallback
+        }
+    }
+
+    func test_autoBackend_whenDisabled_fallsBackObservably() throws {
+        let saved = MetalDispatch.metalDisabled
+        MetalDispatch.metalDisabled = true
+        defer { MetalDispatch.metalDisabled = saved }
+
+        let vectors = seededVectors(count: 512, dims: 8)
+        let df = DataFrame(columns: [
+            ("embedding", try .fromVectors(vectors, dims: 8)),
+        ])
+        var options = SearchOptions()
+        options.backend = .auto(gpuThreshold: 16)
+        let result = try df.similaritySearch(on: "embedding", query: vectors[0], options: options)
+        XCTAssertEqual(result.backendUsed, "cpu-vdsp")
+    }
+}

--- a/Tests/SwiftPandasTests/SPBTests.swift
+++ b/Tests/SwiftPandasTests/SPBTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import SwiftPandas
+
+/// A4 acceptance: SPB round-trip losslessness (all 5 dtypes x null patterns),
+/// double-write byte-identity, and loud rejection of corrupt/truncated/
+/// future-version files.
+final class SPBTests: XCTestCase {
+
+    private func allDtypesFrame() throws -> DataFrame {
+        DataFrame(columns: [
+            ("d", .fromOptionalDoubles([1.5, nil, -3.25, 0])),
+            ("s", .fromOptionalStrings(["hello", nil, "", "utf8 ✓ 日本語"])),
+            ("b", .fromOptionalBools([true, false, nil, true])),
+            ("i", .fromOptionalInts([Int.max, nil, -7, 0])),
+            ("v", try .fromOptionalVectors([[1, 2, 3], nil, [0, 0, 0], [-1.5, 2.5, 3.5]], dims: 3)),
+        ])
+    }
+
+    // MARK: - Round trip
+
+    func test_roundTrip_allDtypes_withNulls() throws {
+        let df = try allDtypesFrame()
+        let restored = try DataFrame.readSPB(from: df.toSPBData())
+
+        XCTAssertEqual(restored.columnNames, df.columnNames)
+        XCTAssertEqual(restored.rowCount, df.rowCount)
+        for name in df.columnNames {
+            XCTAssertEqual(restored.columns[name]!, df.columns[name]!, "column '\(name)'")
+        }
+    }
+
+    func test_roundTrip_emptyStringVsNullString() throws {
+        let df = DataFrame(columns: [("s", .fromOptionalStrings(["", nil]))])
+        let restored = try DataFrame.readSPB(from: df.toSPBData())
+        guard case .string(let a) = restored.columns["s"]! else {
+            return XCTFail("expected string column")
+        }
+        XCTAssertEqual(a[0], "")   // valid empty string survives
+        XCTAssertNil(a[1])          // null stays null — the bitmap disambiguates
+    }
+
+    func test_roundTrip_emptyFrameAndZeroRows() throws {
+        let empty = DataFrame()
+        XCTAssertEqual(try DataFrame.readSPB(from: empty.toSPBData()).rowCount, 0)
+
+        let zeroRows = DataFrame(columns: [("d", .fromDoubles([]))])
+        let restored = try DataFrame.readSPB(from: zeroRows.toSPBData())
+        XCTAssertEqual(restored.columnNames, ["d"])
+        XCTAssertEqual(restored.rowCount, 0)
+    }
+
+    func test_roundTrip_fileURL() throws {
+        let df = try allDtypesFrame()
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("spb_test_\(UUID().uuidString).spb")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try df.writeSPB(to: url)
+        let restored = try DataFrame.readSPB(from: url)
+        XCTAssertEqual(restored.columns["v"]!, df.columns["v"]!)
+    }
+
+    // MARK: - Byte determinism
+
+    func test_doubleWrite_isByteIdentical() throws {
+        let df = try allDtypesFrame()
+        XCTAssertEqual(df.toSPBData(), df.toSPBData())
+        // Equal-but-independently-built frames also produce identical bytes.
+        let rebuilt = try allDtypesFrame()
+        XCTAssertEqual(df.toSPBData(), rebuilt.toSPBData())
+    }
+
+    func test_roundTrip_isByteStable() throws {
+        // write -> read -> write produces the same bytes (canonical form).
+        let df = try allDtypesFrame()
+        let first = df.toSPBData()
+        let second = try DataFrame.readSPB(from: first).toSPBData()
+        XCTAssertEqual(first, second)
+    }
+
+    // MARK: - Corruption / version rejection
+
+    private func expectCorrupt(_ data: Data, _ label: String) {
+        XCTAssertThrowsError(try DataFrame.readSPB(from: data), label) { error in
+            guard case VectorError.corrupt(let reason) = error else {
+                return XCTFail("\(label): expected .corrupt, got \(error)")
+            }
+            XCTAssertFalse(reason.isEmpty)
+        }
+    }
+
+    func test_badMagic_throws() throws {
+        var data = try allDtypesFrame().toSPBData()
+        data[0] = 0x58
+        expectCorrupt(data, "bad magic")
+    }
+
+    func test_futureVersion_throwsVersionUnsupported() throws {
+        var data = try allDtypesFrame().toSPBData()
+        data[4] = 2  // formatVersion LE low byte
+        XCTAssertThrowsError(try DataFrame.readSPB(from: data)) { error in
+            guard case VectorError.versionUnsupported(let found, let supported) = error else {
+                return XCTFail("expected versionUnsupported, got \(error)")
+            }
+            XCTAssertEqual(found, 2)
+            XCTAssertEqual(supported, 1)
+        }
+    }
+
+    func test_truncatedFile_throwsWithReason() throws {
+        let data = try allDtypesFrame().toSPBData()
+        expectCorrupt(data.prefix(data.count / 2), "truncated payload")
+        expectCorrupt(data.prefix(10), "truncated header")
+        expectCorrupt(Data(), "empty file")
+    }
+
+    func test_trailingGarbage_throws() throws {
+        var data = try allDtypesFrame().toSPBData()
+        data.append(contentsOf: [0xDE, 0xAD])
+        expectCorrupt(data, "trailing bytes")
+    }
+
+    func test_unknownDtypeTag_throws() throws {
+        let df = DataFrame(columns: [("d", .fromDoubles([1]))])
+        var data = df.toSPBData()
+        // Header is 20 bytes; name is len(4)+1; tag follows.
+        let tagOffset = 20 + 4 + 1
+        data[tagOffset] = 99
+        expectCorrupt(data, "unknown dtype tag")
+    }
+
+    func test_oversizedStringLength_throws() throws {
+        let df = DataFrame(columns: [("s", .fromStrings(["ab"]))])
+        var data = df.toSPBData()
+        // Last 6 bytes are the cell: UInt32 len ("ab" = 2) + 2 bytes UTF-8.
+        data[data.count - 6] = 0xFF  // now claims a huge length
+        expectCorrupt(data, "oversized string length")
+    }
+
+    func test_nonZeroNullSlot_throws() throws {
+        let df = DataFrame(columns: [("d", .fromOptionalDoubles([nil, 2.0]))])
+        var data = df.toSPBData()
+        // Payload starts after header(20) + name(4+1) + tag(1) + bitmap(1).
+        let payloadOffset = 20 + 5 + 1 + 1
+        data[payloadOffset] = 1  // dirty the null slot
+        expectCorrupt(data, "non-zero null payload slot")
+    }
+
+    func test_nonZeroBitmapTailBit_throws() throws {
+        let df = DataFrame(columns: [("d", .fromDoubles([1.0]))])
+        var data = df.toSPBData()
+        let bitmapOffset = 20 + 5 + 1
+        data[bitmapOffset] = 0xFF  // rows=1 but 8 bits set
+        expectCorrupt(data, "bitmap tail bits")
+    }
+
+    func test_vectorDimsZero_throws() throws {
+        let df = DataFrame(columns: [("v", try .fromVectors([[1]], dims: 1))])
+        var data = df.toSPBData()
+        let dimsOffset = 20 + 5 + 1  // dims UInt32 follows the tag
+        data[dimsOffset] = 0
+        expectCorrupt(data, "dims = 0")
+    }
+}

--- a/Tests/SwiftPandasTests/SwiftPandasTests.swift
+++ b/Tests/SwiftPandasTests/SwiftPandasTests.swift
@@ -43,7 +43,7 @@ import XCTest
 /// Ensures the public `SwiftPandasInfo.version` string matches the expected release.
 final class SwiftPandasTests: XCTestCase {
     func testVersion() {
-        XCTAssertEqual(SwiftPandasInfo.version, "0.7.0-beta")
+        XCTAssertEqual(SwiftPandasInfo.version, "0.8.0-beta")
     }
 }
 

--- a/Tests/SwiftPandasTests/VectorColumnTests.swift
+++ b/Tests/SwiftPandasTests/VectorColumnTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import SwiftPandas
+
+/// R1 acceptance: VectorArray construction, invariants, Column/Series
+/// integration, and accessors.
+final class VectorColumnTests: XCTestCase {
+
+    // MARK: - Construction
+
+    func test_fromVectors_basic() throws {
+        let col = try Column.fromVectors([[1, 2, 3], [4, 5, 6]], dims: 3)
+        XCTAssertEqual(col.count, 2)
+        XCTAssertEqual(col.validCount, 2)
+        XCTAssertEqual(col.naCount, 0)
+        guard case .floatVector(let array) = col else {
+            return XCTFail("expected .floatVector")
+        }
+        XCTAssertEqual(array.dims, 3)
+    }
+
+    func test_fromVectors_dimensionMismatch_throws() {
+        XCTAssertThrowsError(try Column.fromVectors([[1, 2], [1, 2, 3]], dims: 2)) { error in
+            guard case VectorError.dimensionMismatch(let expected, let got) = error else {
+                return XCTFail("expected dimensionMismatch, got \(error)")
+            }
+            XCTAssertEqual(expected, 2)
+            XCTAssertEqual(got, 3)
+        }
+    }
+
+    func test_fromVectors_invalidDims_throws() {
+        XCTAssertThrowsError(try Column.fromVectors([], dims: 0)) { error in
+            guard case VectorError.invalidArgument = error else {
+                return XCTFail("expected invalidArgument, got \(error)")
+            }
+        }
+    }
+
+    func test_fromOptionalVectors_nullsAreZeroFilledAndMasked() throws {
+        let col = try Column.fromOptionalVectors([[1, 1], nil, [2, 2]], dims: 2)
+        XCTAssertEqual(col.count, 3)
+        XCTAssertEqual(col.validCount, 2)
+        XCTAssertEqual(col.naCount, 1)
+        XCTAssertEqual(col.isNA(), [false, true, false])
+        guard case .floatVector(let array) = col else {
+            return XCTFail("expected .floatVector")
+        }
+        // Normative invariant: null rows are zero-filled in the plane.
+        array.plane.withUnsafeBufferPointer { buf in
+            XCTAssertEqual(Array(buf[2..<4]), [0, 0])
+        }
+        XCTAssertNil(array.row(1))
+        XCTAssertEqual(array.row(2), [2, 2])
+    }
+
+    // MARK: - DType
+
+    func test_dtype_reportsDims() throws {
+        let col = try Column.fromVectors([[Float](repeating: 0, count: 1024)], dims: 1024)
+        XCTAssertEqual(col.dtype, .floatVector(dims: 1024))
+        XCTAssertEqual(col.dtype.description, "floatVector(1024)")
+        XCTAssertFalse(col.dtype.isNumeric)
+        XCTAssertFalse(col.isNumeric)
+        // Dims is part of type identity.
+        XCTAssertNotEqual(DTypeEnum.floatVector(dims: 8), DTypeEnum.floatVector(dims: 16))
+    }
+
+    func test_dataFrame_dtypes_reportsVectorColumn() throws {
+        let df = DataFrame(columns: [
+            ("id", .fromInts([1, 2])),
+            ("embedding", try .fromVectors([[1, 0], [0, 1]], dims: 2)),
+        ])
+        let dtype = df.dtypes.first { $0.name == "embedding" }?.dtype
+        XCTAssertEqual(dtype, .floatVector(dims: 2))
+    }
+
+    // MARK: - Series accessors
+
+    func test_series_accessors() throws {
+        let series = try Series(vectors: [[1, 2], [3, 4]], dims: 2, name: "v")
+        XCTAssertEqual(series.vectorDims, 2)
+        XCTAssertEqual(series.vector(at: 0), [1, 2])
+        XCTAssertEqual(series.vectors(), [[1, 2], [3, 4]])
+    }
+
+    func test_vectorDims_isNilForScalarSeries() {
+        let series = Series([1.0, 2.0], name: "x")
+        XCTAssertNil(series.vectorDims)
+    }
+
+    func test_withUnsafeVectorPlane_isZeroCopy() throws {
+        let series = try Series(vectors: [[1, 2], [3, 4]], dims: 2, name: "v")
+        guard case .floatVector(let array) = series.data else {
+            return XCTFail("expected .floatVector")
+        }
+        let expectedBase = array.plane.withUnsafeBufferPointer { $0.baseAddress }
+        series.withUnsafeVectorPlane { plane, dims in
+            XCTAssertEqual(dims, 2)
+            XCTAssertEqual(plane.count, 4)
+            // Same base address as the underlying storage — no copy.
+            XCTAssertEqual(plane.baseAddress, expectedBase)
+        }
+    }
+
+    // MARK: - nbytes
+
+    func test_nbytes_coversPlaneAndBitmap() throws {
+        let col = try Column.fromVectors(
+            Array(repeating: [Float](repeating: 1, count: 8), count: 100), dims: 8)
+        // Plane: 100*8*4 = 3200 bytes, plus bitmap + norm cache.
+        XCTAssertGreaterThanOrEqual(col.nbytes, 3200)
+    }
+
+    // MARK: - take / copy / concat
+
+    func test_take_indices_gathersAndNullsOutOfRange() throws {
+        let array = try VectorArray(vectors: [[1, 1], [2, 2], [3, 3]], dims: 2)
+        let taken = array.take(indices: [2, 0, -1, 99])
+        XCTAssertEqual(taken.count, 4)
+        XCTAssertEqual(taken.row(0), [3, 3])
+        XCTAssertEqual(taken.row(1), [1, 1])
+        XCTAssertNil(taken.row(2))
+        XCTAssertNil(taken.row(3))
+        // Norm cache sliced correctly.
+        taken.squaredNorms.withUnsafeBufferPointer { norms in
+            XCTAssertEqual(norms[0], 18)
+            XCTAssertEqual(norms[2], 0)
+        }
+    }
+
+    func test_take_mask() throws {
+        let array = try VectorArray(vectors: [[1, 1], [2, 2], [3, 3]], dims: 2)
+        let taken = array.take(mask: [true, false, true], trueCount: 2)
+        XCTAssertEqual(taken.count, 2)
+        XCTAssertEqual(taken.row(0), [1, 1])
+        XCTAssertEqual(taken.row(1), [3, 3])
+    }
+
+    func test_concat_matchingDims() throws {
+        let a = try VectorArray(vectors: [[1, 1]], dims: 2)
+        let b = try VectorArray(vectors: [[2, 2], nil], dims: 2)
+        let combined = try VectorArray.concat([a, b])
+        XCTAssertEqual(combined.count, 3)
+        XCTAssertEqual(combined.row(1), [2, 2])
+        XCTAssertNil(combined.row(2))
+    }
+
+    func test_concat_dimsMismatch_throws() throws {
+        let a = try VectorArray(vectors: [[1, 1]], dims: 2)
+        let b = try VectorArray(vectors: [[1, 1, 1]], dims: 3)
+        XCTAssertThrowsError(try VectorArray.concat([a, b])) { error in
+            guard case VectorError.dimensionMismatch = error else {
+                return XCTFail("expected dimensionMismatch, got \(error)")
+            }
+        }
+    }
+
+    func test_copy_isIndependentAndEqual() throws {
+        let col = try Column.fromOptionalVectors([[1, 2], nil], dims: 2)
+        let copied = col.copy()
+        XCTAssertEqual(col, copied)
+    }
+
+    // MARK: - Norm cache
+
+    func test_squaredNorms_cachedAtConstruction() throws {
+        let array = try VectorArray(vectors: [[3, 4], nil, [0, 0]], dims: 2)
+        array.squaredNorms.withUnsafeBufferPointer { norms in
+            XCTAssertEqual(norms[0], 25)
+            XCTAssertEqual(norms[1], 0)  // null row
+            XCTAssertEqual(norms[2], 0)  // zero vector
+        }
+    }
+}

--- a/Tests/SwiftPandasTests/VectorOpsMatrixTests.swift
+++ b/Tests/SwiftPandasTests/VectorOpsMatrixTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import SwiftPandas
+
+/// A5 acceptance: every "MUST work" DataFrame op verified on a mixed
+/// scalar+vector frame; every reachable "MUST throw" op verified to reject
+/// vector columns. (Non-throwing APIs that reject via precondition/fatalError
+/// — CSVWriter.write, merge-on-vector-key, groupBy-on-vector-key — cannot be
+/// asserted in XCTest and are covered by the throwing entry points plus code
+/// review; see the vector spec's ops matrix.)
+final class VectorOpsMatrixTests: XCTestCase {
+
+    private func mixedFrame() throws -> DataFrame {
+        DataFrame(columns: [
+            ("id", .fromInts([1, 2, 3, 4])),
+            ("label", .fromStrings(["a", "b", "c", "d"])),
+            ("embedding", try .fromOptionalVectors([[1, 0], [0, 1], nil, [1, 1]], dims: 2)),
+        ])
+    }
+
+    // MARK: - MUST work
+
+    func test_filterMask_carriesVectorColumn() throws {
+        let df = try mixedFrame()
+        let filtered = df.filter(mask: [true, false, true, false])
+        XCTAssertEqual(filtered.rowCount, 2)
+        XCTAssertEqual(filtered["embedding"].vector(at: 0), [1, 0])
+        XCTAssertNil(filtered["embedding"].vector(at: 1))
+    }
+
+    func test_takeRows_carriesVectorColumn() throws {
+        let df = try mixedFrame()
+        let taken = df.takeRows([3, 0])
+        XCTAssertEqual(taken["embedding"].vector(at: 0), [1, 1])
+        XCTAssertEqual(taken["embedding"].vector(at: 1), [1, 0])
+    }
+
+    func test_iloc_headTail_selectDropRename() throws {
+        let df = try mixedFrame()
+        XCTAssertEqual(df.iloc(0..<2).rowCount, 2)
+        XCTAssertEqual(df.head(1)["embedding"].vector(at: 0), [1, 0])
+        XCTAssertEqual(df.tail(1)["embedding"].vector(at: 0), [1, 1])
+
+        let selected = df.select(columns: ["id", "embedding"])
+        XCTAssertEqual(selected.columnNames, ["id", "embedding"])
+
+        let dropped = df.drop(columns: ["embedding"])
+        XCTAssertFalse(dropped.columnNames.contains("embedding"))
+
+        let renamed = df.rename(columns: ["embedding": "vec"])
+        XCTAssertEqual(renamed["vec"].vectorDims, 2)
+    }
+
+    func test_concat_sharesDims() throws {
+        let df = try mixedFrame()
+        let combined = DataFrame.concat([df, df])
+        XCTAssertEqual(combined.rowCount, 8)
+        XCTAssertEqual(combined["embedding"].vector(at: 4), [1, 0])
+        XCTAssertNil(combined["embedding"].vector(at: 6))
+    }
+
+    func test_merge_vectorPassesThroughAsPayload() throws {
+        let left = try mixedFrame()
+        let right = DataFrame(columns: [
+            ("id", .fromInts([2, 4])),
+            ("extra", .fromDoubles([20, 40])),
+        ])
+        let merged = left.merge(right, on: "id", how: .inner)
+        XCTAssertEqual(merged.rowCount, 2)
+        XCTAssertEqual(merged["embedding"].vector(at: 0), [0, 1])
+        XCTAssertEqual(merged["embedding"].vector(at: 1), [1, 1])
+    }
+
+    func test_estimatedBytes_includesVectorColumn() throws {
+        let df = try mixedFrame()
+        let withoutVector = df.drop(columns: ["embedding"])
+        XCTAssertGreaterThan(df.estimatedBytes, withoutVector.estimatedBytes)
+    }
+
+    func test_describe_vectorSeries_reportsCountNullsDims() throws {
+        let df = try mixedFrame()
+        let stats = df["embedding"].describe()
+        XCTAssertEqual(stats.indexLabels, ["count", "nulls", "dims"])
+        XCTAssertEqual(stats.data.value(at: 0) as? Double, 4)
+        XCTAssertEqual(stats.data.value(at: 1) as? Double, 1)
+        XCTAssertEqual(stats.data.value(at: 2) as? Double, 2)
+    }
+
+    func test_dataFrameDescribe_skipsVectorColumn() throws {
+        // Whole-frame describe sweeps numeric columns only; the vector column
+        // is skipped exactly as string columns are (deviation #2 in the spec).
+        let df = try mixedFrame()
+        XCTAssertNoThrow(df.describe())
+    }
+
+    func test_sortValues_byScalar_carriesVectorColumn() throws {
+        let df = try mixedFrame()
+        let sorted = df.sortValues(by: "id", ascending: false)
+        XCTAssertEqual(sorted["embedding"].vector(at: 0), [1, 1])
+    }
+
+    // MARK: - MUST throw
+
+    func test_toCSV_path_throwsUnsupported() throws {
+        let df = try mixedFrame()
+        let path = NSTemporaryDirectory() + "/vector_test.csv"
+        XCTAssertThrowsError(try df.toCSV(path: path)) { error in
+            guard case VectorError.unsupportedOperation(let op, let dtype) = error else {
+                return XCTFail("expected unsupportedOperation, got \(error)")
+            }
+            XCTAssertEqual(op, "toCSV")
+            XCTAssertEqual(dtype, "floatVector(2)")
+        }
+    }
+
+    func test_toJSON_path_throwsUnsupported() throws {
+        let df = try mixedFrame()
+        let path = NSTemporaryDirectory() + "/vector_test.json"
+        XCTAssertThrowsError(try df.toJSON(path: path)) { error in
+            guard case VectorError.unsupportedOperation = error else {
+                return XCTFail("expected unsupportedOperation, got \(error)")
+            }
+        }
+    }
+
+    func test_toCSV_afterDroppingVector_works() throws {
+        // The documented escape hatch: CSV of the scalar columns via drop.
+        let df = try mixedFrame().drop(columns: ["embedding"])
+        let csv = df.toCSV()
+        XCTAssertTrue(csv.contains("id"))
+    }
+
+    func test_l2NormsAndNormalize_throwOnScalarSeries() {
+        let series = Series([1.0, 2.0], name: "x")
+        XCTAssertThrowsError(try series.l2Norms())
+        XCTAssertThrowsError(try series.normalizedL2())
+    }
+
+    // MARK: - Vector ops (R2)
+
+    func test_l2Norms() throws {
+        let series = try Series(vectors: [[3, 4], [0, 0]], dims: 2, name: "v")
+        XCTAssertEqual(try series.l2Norms(), [5, 0])
+    }
+
+    func test_normalizedL2_zeroNormStaysZero_storageStaysRaw() throws {
+        let series = Series(
+            data: try .fromOptionalVectors([[3, 4], [0, 0], nil], dims: 2), name: "v")
+        let normalized = try series.normalizedL2()
+        XCTAssertEqual(normalized.vector(at: 0), [0.6, 0.8])
+        XCTAssertEqual(normalized.vector(at: 1), [0, 0])
+        XCTAssertNil(normalized.vector(at: 2))
+        // Raw-storage invariant: the source series is untouched.
+        XCTAssertEqual(series.vector(at: 0), [3, 4])
+    }
+
+    // MARK: - Scalar aggregations skip vectors
+
+    func test_columnAggregations_returnNilForVector() throws {
+        let col = try Column.fromVectors([[1, 2]], dims: 2)
+        XCTAssertNil(col.sum())
+        XCTAssertNil(col.mean())
+        XCTAssertNil(col.asDouble())
+    }
+}

--- a/Tests/SwiftPandasTests/VectorSearchTests.swift
+++ b/Tests/SwiftPandasTests/VectorSearchTests.swift
@@ -1,0 +1,252 @@
+import XCTest
+@testable import SwiftPandas
+
+/// A1 (numeric pins) + A2 (determinism) acceptance for CPU similarity search.
+final class VectorSearchTests: XCTestCase {
+
+    private func frame(_ vectors: [[Float]?], dims: Int) throws -> DataFrame {
+        DataFrame(columns: [
+            ("id", .fromInts(Array(0..<vectors.count))),
+            ("embedding", try .fromOptionalVectors(vectors, dims: dims)),
+        ])
+    }
+
+    private func scores(_ result: SearchResultFrame) -> [Double] {
+        guard case .double(let a) = result.frame["__score"].data else { return [] }
+        return (0..<a.count).map { a[$0]! }
+    }
+
+    private func ids(_ result: SearchResultFrame) -> [Int64] {
+        guard case .int64(let a) = result.frame["id"].data else { return [] }
+        return (0..<a.count).map { a[$0]! }
+    }
+
+    // MARK: - A1 numeric pins (exact, per the bit-parity contract)
+
+    func test_cosine_identicalVectors_isExactlyOne() throws {
+        // Note: the exactness pin holds under the normative §4.2 float order
+        // when norm² has an exact Float sqrt ([3,4] -> 25 -> 5). For general
+        // vectors ([1,2,3]) sqrt(14)² rounds to 14.000001 in Float32 and the
+        // pinned order — deliberately — does not fudge it back to 1.0.
+        let df = try frame([[3, 4]], dims: 2)
+        let result = try df.similaritySearch(on: "embedding", query: [3, 4])
+        XCTAssertEqual(scores(result), [1.0])
+        XCTAssertEqual(result.backendUsed, "cpu-vdsp")
+    }
+
+    func test_cosine_orthogonal_isExactlyZero() throws {
+        let df = try frame([[0, 1]], dims: 2)
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0])
+        XCTAssertEqual(scores(result), [0.0])
+    }
+
+    func test_cosine_opposite_isExactlyMinusOne() throws {
+        let df = try frame([[-3, -4]], dims: 2)
+        let result = try df.similaritySearch(on: "embedding", query: [3, 4])
+        XCTAssertEqual(scores(result), [-1.0])
+    }
+
+    func test_cosine_zeroVector_isExactlyZero() throws {
+        // Either-zero-norm -> score 0.0, both directions.
+        let df = try frame([[0, 0], [1, 1]], dims: 2)
+        let zeroQuery = try df.similaritySearch(on: "embedding", query: [0, 0])
+        XCTAssertEqual(scores(zeroQuery), [0.0, 0.0])
+        let zeroCandidate = try df.similaritySearch(on: "embedding", query: [1, 0])
+        XCTAssertEqual(scores(zeroCandidate).last, 0.0)  // the [0,0] row
+    }
+
+    func test_dot_direction_higherIsBetter() throws {
+        let df = try frame([[1, 0], [3, 0], [2, 0]], dims: 2)
+        var options = SearchOptions()
+        options.metric = .dot
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0], options: options)
+        XCTAssertEqual(ids(result), [1, 2, 0])
+        XCTAssertEqual(scores(result), [3.0, 2.0, 1.0])
+    }
+
+    func test_euclidean_direction_lowerIsBetter() throws {
+        let df = try frame([[3, 0], [1, 0], [2, 0]], dims: 2)
+        var options = SearchOptions()
+        options.metric = .euclidean
+        let result = try df.similaritySearch(on: "embedding", query: [0, 0], options: options)
+        XCTAssertEqual(ids(result), [1, 2, 0])
+        XCTAssertEqual(scores(result), [1.0, 2.0, 3.0])
+    }
+
+    func test_threshold_perMetricDirection() throws {
+        let df = try frame([[1, 0], [0, 1], [-1, 0]], dims: 2)
+        var options = SearchOptions()
+        options.threshold = 0.5  // cosine: keep score >= 0.5
+        let kept = try df.similaritySearch(on: "embedding", query: [1, 0], options: options)
+        XCTAssertEqual(ids(kept), [0])
+
+        var euclid = SearchOptions()
+        euclid.metric = .euclidean
+        euclid.threshold = 1.5  // euclidean: keep distance <= 1.5
+        let near = try df.similaritySearch(on: "embedding", query: [1, 0], options: euclid)
+        XCTAssertEqual(ids(near), [0, 1])  // distances 0, sqrt(2); [-1,0] is 2 away
+    }
+
+    func test_topK_truncatesAfterThreshold() throws {
+        let df = try frame([[1, 0], [1, 0], [1, 0], [0, 1]], dims: 2)
+        var options = SearchOptions()
+        options.topK = 2
+        options.threshold = 0.5
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0], options: options)
+        XCTAssertEqual(result.frame.rowCount, 2)
+        XCTAssertEqual(ids(result), [0, 1])  // tie-break: lower row index first
+    }
+
+    // MARK: - A2 determinism
+
+    func test_repeatedSearches_returnBitEqualScores() throws {
+        var vectors = [[Float]]()
+        var seed: UInt64 = 42
+        for _ in 0..<500 {
+            var v = [Float]()
+            for _ in 0..<32 {
+                seed = seed &* 6364136223846793005 &+ 1442695040888963407
+                v.append(Float(seed >> 40) / Float(1 << 24))
+            }
+            vectors.append(v)
+        }
+        let df = try frame(vectors, dims: 32)
+        var options = SearchOptions()
+        options.topK = 50
+        let first = try df.similaritySearch(on: "embedding", query: vectors[7], options: options)
+        for _ in 0..<3 {
+            let again = try df.similaritySearch(on: "embedding", query: vectors[7], options: options)
+            // Bit-pattern comparison: -0.0 / NaN drift cannot pass silently.
+            XCTAssertEqual(
+                scores(first).map { $0.bitPattern },
+                scores(again).map { $0.bitPattern })
+            XCTAssertEqual(ids(first), ids(again))
+        }
+    }
+
+    func test_tieBreak_duplicatedVectors_sourceRowIndexAscending() throws {
+        let df = try frame([[0, 1], [1, 0], [1, 0], [1, 0]], dims: 2)
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0])
+        // Rows 1–3 are exact duplicates (score 1.0) -> source index order;
+        // orthogonal row 0 (score 0.0) ranks last.
+        XCTAssertEqual(scores(result), [1.0, 1.0, 1.0, 0.0])
+        XCTAssertEqual(ids(result), [1, 2, 3, 0])
+    }
+
+    // MARK: - Batch ≡ sequential
+
+    func test_batch_identicalToSequential() throws {
+        let vectors: [[Float]] = [[1, 0], [0, 1], [1, 1], [-1, 0]]
+        let df = try frame(vectors, dims: 2)
+        let queries: [[Float]] = [[1, 0], [0, 1]]
+        let batch = try df.similaritySearchBatch(on: "embedding", queries: queries)
+        let sequential = try queries.map { try df.similaritySearch(on: "embedding", query: $0) }
+        XCTAssertEqual(batch.count, sequential.count)
+        for (b, s) in zip(batch, sequential) {
+            XCTAssertEqual(scores(b).map { $0.bitPattern }, scores(s).map { $0.bitPattern })
+            XCTAssertEqual(ids(b), ids(s))
+            XCTAssertEqual(b.backendUsed, s.backendUsed)
+        }
+    }
+
+    // MARK: - Candidate exclusion
+
+    func test_nullRowsExcludedBeforeScoring() throws {
+        let df = try frame([[1, 0], nil, [0, 1]], dims: 2)
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0])
+        XCTAssertEqual(ids(result), [0, 2])  // null row 1 never scored
+    }
+
+    func test_maskExcludesCandidates() throws {
+        let df = try frame([[1, 0], [1, 0], [0, 1]], dims: 2)
+        var options = SearchOptions()
+        options.mask = [false, true, true]
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0], options: options)
+        XCTAssertEqual(ids(result), [1, 2])
+    }
+
+    func test_emptyResult_isValidNotError() throws {
+        let df = try frame([[1, 0]], dims: 2)
+        var options = SearchOptions()
+        options.threshold = 0.99
+        let result = try df.similaritySearch(on: "embedding", query: [0, 1], options: options)
+        XCTAssertEqual(result.frame.rowCount, 0)
+    }
+
+    // MARK: - Validation errors
+
+    func test_missingColumn_throwsDataFrameError() throws {
+        let df = try frame([[1, 0]], dims: 2)
+        XCTAssertThrowsError(try df.similaritySearch(on: "nope", query: [1, 0])) { error in
+            guard case DataFrameError.columnNotFound(let name) = error else {
+                return XCTFail("expected columnNotFound, got \(error)")
+            }
+            XCTAssertEqual(name, "nope")
+        }
+    }
+
+    func test_scalarColumn_throwsUnsupported() throws {
+        let df = try frame([[1, 0]], dims: 2)
+        XCTAssertThrowsError(try df.similaritySearch(on: "id", query: [1, 0])) { error in
+            guard case VectorError.unsupportedOperation = error else {
+                return XCTFail("expected unsupportedOperation, got \(error)")
+            }
+        }
+    }
+
+    func test_queryDimsMismatch_throws() throws {
+        let df = try frame([[1, 0]], dims: 2)
+        XCTAssertThrowsError(try df.similaritySearch(on: "embedding", query: [1, 0, 0])) { error in
+            guard case VectorError.dimensionMismatch(let expected, let got) = error else {
+                return XCTFail("expected dimensionMismatch, got \(error)")
+            }
+            XCTAssertEqual(expected, 2)
+            XCTAssertEqual(got, 3)
+        }
+    }
+
+    func test_emptyQuery_throwsInvalidArgument() throws {
+        let df = try frame([[1, 0]], dims: 2)
+        XCTAssertThrowsError(try df.similaritySearch(on: "embedding", query: [])) { error in
+            guard case VectorError.invalidArgument = error else {
+                return XCTFail("expected invalidArgument, got \(error)")
+            }
+        }
+    }
+
+    func test_nonPositiveTopK_throws() throws {
+        let df = try frame([[1, 0]], dims: 2)
+        var options = SearchOptions()
+        options.topK = 0
+        XCTAssertThrowsError(
+            try df.similaritySearch(on: "embedding", query: [1, 0], options: options)) { error in
+            guard case VectorError.invalidArgument = error else {
+                return XCTFail("expected invalidArgument, got \(error)")
+            }
+        }
+    }
+
+    func test_maskLengthMismatch_throws() throws {
+        let df = try frame([[1, 0], [0, 1]], dims: 2)
+        var options = SearchOptions()
+        options.mask = [true]
+        XCTAssertThrowsError(
+            try df.similaritySearch(on: "embedding", query: [1, 0], options: options)) { error in
+            guard case VectorError.maskLengthMismatch(let expected, let got) = error else {
+                return XCTFail("expected maskLengthMismatch, got \(error)")
+            }
+            XCTAssertEqual(expected, 2)
+            XCTAssertEqual(got, 1)
+        }
+    }
+
+    // MARK: - Result frame shape
+
+    func test_resultFrame_hasOriginalColumnsPlusScore() throws {
+        let df = try frame([[1, 0], [0, 1]], dims: 2)
+        let result = try df.similaritySearch(on: "embedding", query: [1, 0])
+        XCTAssertEqual(result.frame.columnNames, ["id", "embedding", "__score"])
+        // The vector column rides along intact through the result.
+        XCTAssertEqual(result.frame["embedding"].vector(at: 0), [1, 0])
+    }
+}

--- a/docs/vector-spec.md
+++ b/docs/vector-spec.md
@@ -1,0 +1,321 @@
+# SwiftPandas Vector Functionality — Design Specification
+
+**Status:** Draft for implementation
+**Date:** 2026-07-18
+**Responds to:** Kiraa Engine "Vector Database Functionality — Requirements Specification" (R1–R8, A1–A6)
+**Target release:** **0.8.0** — *not* 0.7.0 as the request assumes. `SwiftPandasInfo.version` is already `0.7.0-beta` (commit `27c3f2c`, the hot-cache release). The requirements doc was written against 0.6.0-beta; the version target is the only clause we cannot honor as written. Everything else below is spec'd to satisfy the request normatively.
+
+---
+
+## 0. Design stance
+
+Three principles drive every decision here (per our design review discipline):
+
+1. **One deep module per design decision.** Vector storage layout lives only in `VectorArray`; candidate selection lives only in the search engine; byte layout lives only in the SPB reader/writer. No other file may know these decisions.
+2. **Reuse the existing machinery, don't parallel it.** SwiftPandas already has a validity bitmap (`BitVector`), CoW contiguous storage (`NativeArray`/`ArrayBuffer`), a Metal runtime-compile pipeline (`MetalShaders` + `MetalContext`), and row materialization (`takeRows`). Every requirement below maps onto one of these rather than introducing a sibling mechanism.
+3. **Define errors out of existence where semantics allow; throw typed errors where the contract demands it.** The request's no-silent-fallback rule (backend policy, ops matrix) is normative — those paths throw `VectorError`, never degrade quietly.
+
+Module inventory (new files):
+
+```
+Sources/SwiftPandas/Vector/VectorArray.swift      // storage (R1)
+Sources/SwiftPandas/Vector/VectorError.swift      // error model (R7)
+Sources/SwiftPandas/Vector/VectorOps.swift        // norms/normalize, Series accessors (R1.3, R2)
+Sources/SwiftPandas/Vector/VectorSearch.swift     // options/backend/result + CPU engine (R3)
+Sources/SwiftPandas/Metal/MetalVectorSearch.swift // GPU dispatch (R5)
+Sources/SwiftPandas/IO/SPB/SPBFormat.swift        // layout constants, tags, cursor
+Sources/SwiftPandas/IO/SPB/SPBWriter.swift        // (R6)
+Sources/SwiftPandas/IO/SPB/SPBReader.swift        // (R6)
+```
+
+plus edits to the existing switch sites enumerated in §7 (the A6 audit list).
+
+---
+
+## 1. R1 — `VectorArray` and the `Column` case
+
+### 1.1 Storage design
+
+**Design it twice.** Two candidate representations were considered:
+
+- *(a)* `NullableArray<[Float]>` — reuses the generic container wholesale. Rejected: element type `[Float]` is heap-boxed per row (array-of-arrays by the back door), violates the flat-plane requirement, and `NullableArray`'s vDSP fast paths are meaningless for it.
+- *(b)* A purpose-built struct composing the two primitives that already encode our storage decisions: `NativeArray<Float>` for the plane (CoW via `ArrayBuffer`), `BitVector` for validity. **Chosen.** This *is* "reusing the NullableArray bitmap machinery" — `BitVector` is that machinery; `NullableArray` is merely one composition of it.
+
+```swift
+/// Fixed-dims Float32 vector storage: a flat row-major plane + validity bitmap.
+/// Immutable after construction; all row ops return new values (CoW on the plane).
+public struct VectorArray: Sendable, Equatable {
+    internal var plane: NativeArray<Float>   // count * dims, row-major
+    internal var validity: BitVector         // 1 = valid; null rows zero-filled in plane
+    public let dims: Int                     // >= 1, fixed for the array's lifetime
+
+    /// Cached vDSP_dotpr(v, v) per row, computed once at construction.
+    /// §3.2 bit-parity allows this: vDSP_dotpr on the same bytes is
+    /// bit-identical whenever computed. Sliced (not recomputed) by take/copy.
+    internal var squaredNorms: NativeArray<Float>
+
+    public var count: Int { plane.count / dims }
+    public var nbytes: Int   // plane + validity + squaredNorms
+}
+```
+
+Decisions folded into this one type (information hiding — no other file may depend on them):
+
+- **Row-major flat plane, zero-filled null slots.** Zero-fill happens at construction and is an invariant, giving SPB byte-determinism for free (§5) and letting the GPU upload the plane pointer directly.
+- **Eager norm cache.** Cosine needs `‖candidate‖²` per row; computing it lazily would require interior mutability on a `Sendable` struct. One extra vDSP pass at construction (≈ the cost of a single search) buys a halved per-search cost forever, and stays inside the `fromVectors` ≤ 500 ms budget. `take`/`copy` slice the cache alongside the plane — never recompute (recompute would also be bit-identical, but slicing is cheaper and obviously correct).
+- **`dims >= 1` and `plane.count == count * dims == validity.bitCount * dims` are construction-time invariants**, checked once (`VectorError.invalidArgument` / `.dimensionMismatch`), so every downstream consumer can assume them (errors defined out of existence past the constructor).
+
+Row ops mirror the existing `Column` needs — hand-written like the `.bool` case (a `[Float]` row is not `ExpressibleByIntegerLiteral`, so the generic `NullableArray.take` path is unavailable; this is established precedent, see `Column.swift:333–388`):
+
+```swift
+extension VectorArray {
+    func take(indices: [Int]) -> VectorArray          // gathers dims-wide slices + bitmap bits + norms
+    func take(mask: [Bool], trueCount: Int) -> VectorArray
+    func copy() -> VectorArray
+    static func concat(_ arrays: [VectorArray]) throws -> VectorArray  // dims must match: .dimensionMismatch
+}
+```
+
+### 1.2 `Column` and `DTypeEnum`
+
+- `Column` gains `case floatVector(VectorArray)` in `Core/Array/Column.swift`.
+- `DTypeEnum` gains `case floatVector(dims: Int)` in `Core/DType/DType.swift`. **Associated value, deliberately**: dims is part of the type identity (Arrow's `FixedSizeList<Float32>[1024]` precedent) — two vector columns of different dims must not compare dtype-equal, `concat`/SPB validation get dims equality for free from `==`, and `description` renders `"floatVector(1024)"` as required. Hashable/Equatable synthesis still works; `isNumeric`/`isInteger`/`isFloat` return `false` (vector columns are explicitly non-numeric-scalar; every numeric fast-path gates on `asDouble()`, which returns `nil` — see §4).
+- Making both enums grow a case is *intentionally source-breaking inside the library* — that is the A6 enforcement mechanism (§7).
+
+### 1.3 Construction and access
+
+Exactly as the request specifies (signatures normative):
+
+```swift
+extension Column {
+    public static func fromVectors(_ vectors: [[Float]], dims: Int) throws -> Column
+    public static func fromOptionalVectors(_ vectors: [[Float]?], dims: Int) throws -> Column
+}
+public extension Series {
+    init(vectors: [[Float]], dims: Int, name: String) throws
+}
+extension Series {
+    public var vectorDims: Int? { get }            // nil unless .floatVector
+    public func vector(at row: Int) -> [Float]?    // nil for null rows; copies
+    public func vectors() -> [[Float]?]            // copies
+    public func withUnsafeVectorPlane<R>(
+        _ body: (UnsafeBufferPointer<Float>, _ dims: Int) throws -> R) rethrows -> R
+}
+```
+
+- `withUnsafeVectorPlane` delegates to `NativeArray.withUnsafeBufferPointer` — the zero-copy path already exists; we expose it, we don't build it. Calling it on a non-vector series throws `VectorError.unsupportedOperation` (as do `vector(at:)`/`vectors()` — the request marks the whole access group "only valid on floatVector series"; only `vectorDims` is the safe probe, returning `nil`).
+- `DataFrame.init(columns:)` (`DataFrame.swift:279`) needs **no signature change**; row-count consistency checks already operate on `Column.count`, which the new case implements.
+- `fromVectors` performance: single `reserveCapacity(count*dims)` + per-row `memcpy`-style append; no intermediate `[[Float]]` restructuring. Dimension check per element before copy (`.dimensionMismatch(expected:got:)`).
+
+---
+
+## 2. R2 — Vector ops
+
+```swift
+public enum DistanceMetric: String, Sendable, Codable, CaseIterable {
+    case cosine, dot, euclidean
+}
+extension Series {
+    public func l2Norms() throws -> [Float]        // sqrt of cached squaredNorms; null rows -> 0
+    public func normalizedL2() throws -> Series    // new series; zero-norm rows stay zero
+}
+```
+
+- Both throw `unsupportedOperation` on non-vector series.
+- **Raw-storage invariant** (normative, from the request): no code path — constructor, IO, search — may normalize in place. `normalizedL2()` is the only normalizer and always returns a new value. This is documented on `VectorArray` itself as a cross-module invariant, because it is the premise of the §3.2 bit-parity contract.
+- `l2Norms` reads the cached `squaredNorms` (`sqrt` per element via vDSP) — consistent by construction with what search uses.
+
+---
+
+## 3. R3 — Similarity search
+
+### 3.1 Module decomposition
+
+**Design it twice.** *(a)* Put scoring logic directly in the `DataFrame` extension. Rejected: `similaritySearch`, `similaritySearchBatch`, and the Metal path would each re-derive candidate filtering and selection — information leakage across three sites. *(b)* **Chosen:** an internal engine with one narrow entry point; the public `DataFrame` API is a thin, obvious facade.
+
+```swift
+// VectorSearch.swift (internal)
+enum VectorSearchEngine {
+    struct Hits { let rowIndices: [Int]; let scores: [Double]; let backendUsed: String }
+    /// The single implementation of: candidate compaction → scoring → threshold → top-K → tie-break.
+    static func search(_ array: VectorArray, query: [Float], options: SearchOptions) throws -> Hits
+}
+
+extension DataFrame {
+    public func similaritySearch(on column: String, query: [Float],
+                                 options: SearchOptions = .init()) throws -> SearchResultFrame {
+        // 1. resolve column (.floatVector or throw), validate query dims / topK / mask length
+        // 2. let hits = try VectorSearchEngine.search(...)
+        // 3. frame = takeRows(hits.rowIndices) + append "__score" Double column
+    }
+}
+```
+
+Row materialization reuses `takeRows(_:)` (`DataFrame.swift:611`) — search owns *which* rows, never *how* rows are copied. `SearchOptions`, `SearchBackend`, `SearchResultFrame` are exactly as the request defines them (defaults included); `SearchOptions.init()` keeps the common call `df.similaritySearch(on: "embedding", query: q)` one line — rare knobs (mask, backend, threshold) never tax the common path.
+
+### 3.2 Engine pipeline (single ordering of decisions)
+
+1. **Compact candidates once**: `candidateRows: [Int32]` = rows that are bitmap-valid AND mask-true (mask length pre-validated → `.maskLengthMismatch`). Both CPU and GPU paths consume this one list; the GPU path additionally gathers a compacted plane for upload (§6). Null/mask exclusion therefore *cannot* diverge between backends.
+2. **Score** per backend (below).
+3. **Threshold filter** in metric direction (`>=` for cosine/dot, `<=` for euclidean).
+4. **Top-K select** with the comparator `(better score, then lower source row index)` — a bounded max-heap of size K over the surviving candidates (O(n log K)), fully deterministic. `topK <= 0` was already rejected at validation (`.invalidArgument`).
+5. Emit `Hits` best-first.
+
+Steps 3–5 are backend-independent CPU code — the GPU produces raw scores only, so ranking semantics exist in exactly one place.
+
+**Batch**: v1 executes queries sequentially in order — semantic identity with N single calls is then true by construction, not by testing. (The request permits internal parallelism; that is a pure optimization behind the same contract and is deferred until profiling demands it.)
+
+### 3.3 Normative numeric contract (bit-parity, CPU backend)
+
+Pinned exactly as requested; this is the clause Kiraa re-pins on their side, so it is reproduced in the code as an interface comment on the CPU scorer and must never be "optimized":
+
+- **cosine**, per candidate, all Float32:
+  1. `dot = vDSP_dotpr(query, candidate)`
+  2. `nQ = vDSP_dotpr(query, query)` (once per query); `nC` = the cached `squaredNorms[row]` (bit-identical to on-the-fly per the request's own allowance)
+  3. `denom = sqrt(nQ) * sqrt(nC)` (Float sqrts, Float multiply)
+  4. `denom == 0 → score = 0.0`; else `score = Double(dot / denom)` (Float divide, then widen)
+- **dot**: `score = Double(vDSP_dotpr(q, c))`
+- **euclidean** (pinned float-order, to be echoed in the public docs): `d2 = vDSP_distancesq(q, c)` (Float); `score = Double(sqrt(d2))` — `sqrt` applied in Float32, then widened.
+
+No Double accumulation, no FMA rearrangement, no epsilon guards. The scorer walks the plane via `withUnsafeVectorPlane` — no per-row `[Float]` materialization (the R8 no-hidden-copies clause).
+
+---
+
+## 4. R4 — Ops matrix
+
+The mechanical rule: everything that routes through `Column.take`/`copy`/`nbytes`/`count` works automatically once `VectorArray` implements those (**filter(mask:), takeRows, iloc, select, drop, rename, head/tail** — zero per-op code). The rest is explicit:
+
+| Op | Behavior | Where |
+|---|---|---|
+| `concat` | dims equality across frames' same-named vector columns, else `.dimensionMismatch`; `VectorArray.concat` (BitVector already has `append(contentsOf:)`/`concat`) | `DataFrame.swift:1097–1127` |
+| `merge` payload | pass-through via `take` on the join result indices | `DataFrame.swift:1206` |
+| `merge` join key / `joinKeyText` | `unsupportedOperation(op: "merge(on:)", dtype: "floatVector(d)")` | `DataFrame.swift`, `DataFrame+JoinIndex.swift:102` |
+| `describe` | count / nulls / dims only | `Series.swift` describe path |
+| `estimatedBytes` / `nbytes` | `VectorArray.nbytes` (keeps HotStore's `FrameCache` budgeting correct) | automatic |
+| `sortValues` by vector col | `unsupportedOperation` | `DataFrame.swift:702–809` SortKey extraction, `Series.sortValues` |
+| Series arithmetic / comparisons / `apply` numeric / `cumsum` etc. | `unsupportedOperation` | `Series.swift` (these currently `guard case .double`-degrade; vector case made an explicit throw where the API can throw, `fatalError`-precondition where the existing operator API cannot — matching the codebase's operator convention) |
+| `toCSV` with any vector column present | `unsupportedOperation` (checked up front, before any bytes are written) | `CSVReader.swift:1112` writer |
+| `readCSV` | cannot produce vectors (inference emits only double/string — unchanged); strict-contract targets do not add a vector target in v1 | — |
+| JSON writer | vector columns rejected with `unsupportedOperation` (its `value(at:)`-driven path would otherwise silently emit arrays — an untested serialization surface; SPB is the durable format) | `JSONReader.swift` |
+
+**One interpretation decision (flagged for Kiraa sign-off):** whole-frame numeric reductions (`df.mean()`, `df.describe()` over all columns, groupBy over "all numeric columns") today *silently skip* string/bool columns. For consistency, vector columns are skipped by those implicit all-numeric sweeps exactly as strings are; the required `unsupportedOperation` throw applies when a vector column is **explicitly named** in an aggregation (e.g. `series.sum()`, groupBy agg on that column). Throwing on implicit sweeps would make `df.describe()` unusable on any mixed frame, which contradicts R4's own "describe MUST work" row. If Kiraa needs the stricter reading, it is a two-line change at the sweep sites.
+
+---
+
+## 5. R6 — SPB binary format
+
+### 5.1 Placement and shape
+
+`IO/SPB/` beside `IO/CSV/` and `IO/JSON/`. Public surface exactly:
+
+```swift
+extension DataFrame {
+    public func writeSPB(to url: URL) throws
+    public static func readSPB(from url: URL) throws -> DataFrame
+}
+```
+
+Layout is byte-for-byte the table in the request (magic `SPB1`, version 1, little-endian, per-column: name / dtype tag 0–4 / dims (tag 4 only) / LSB-first validity bitmap ⌈rows/8⌉ / payload).
+
+### 5.2 Determinism (normative)
+
+- Column iteration order = `columnNames` (the frame's declared order — the codebase's dual `columnNames: [String]` + `columns: [String: Column]` storage means the array, never the dictionary, drives serialization; this is *the* map-iteration-order hazard in this codebase and is called out in the writer's interface comment).
+- Bitmap serialization: `BitVector` stores packed `UInt64` words; the writer emits exactly `⌈rows/8⌉` bytes, LSB-first within each byte, tail bits of the final byte zero. This byte-level definition (not the in-memory word layout) is the format — `BitVector`'s internal representation stays hidden.
+- Null payload slots: doubles/int64 write 8 zero bytes, bool writes `0`, string writes len `0`, vector rows are already zero-filled in the plane (the §1.1 invariant pays off here — the writer streams the plane verbatim, no masking pass). Note: a valid empty string and a null string both write len 0; the bitmap disambiguates.
+- No timestamps, no padding, no alignment sections. Two writes of equal frames are byte-identical (A4 pins this).
+
+### 5.3 Reading — one validation mechanism, not scattered checks
+
+All reads go through an internal bounds-checked cursor:
+
+```swift
+struct SPBCursor {          // SPBFormat.swift
+    mutating func readU32() throws -> UInt32   // every primitive read validates remaining
+    mutating func readBytes(_ n: Int) throws -> ...
+    // overrun/overflow anywhere → VectorError.corrupt(reason: "...")
+}
+```
+
+so truncation/corruption is impossible to mishandle at call sites — the reader body is straight-line layout code with no inline bounds arithmetic (complexity pulled down into the cursor). Validation order: magic → version (`> 1` → `.versionUnsupported(found:supported:)`) → column count/row count sanity (length arithmetic in `Int` with overflow checks) → per-column tag validity, dims ≥ 1, bitmap tail-bit zeroing, payload length consistency. Any failure throws before a `DataFrame` is constructed — **no partial loads** by construction. String cells: bitmap-invalid ⇒ cell forced null regardless of payload len (len must be 0 or the file is `.corrupt`).
+
+Version 1 readers reject version 2 files loudly (`versionUnsupported`) — the version field is the seam for a future ANN-sidecar section, per the request's non-goals.
+
+### 5.4 Performance
+
+Writer: single pre-sized `Data` buffer (size computed exactly from `nbytes`-style accounting), `append` of raw plane bytes via `withUnsafeBufferPointer` — no per-row loops for fixed-width payloads. Reader: `Data(contentsOf:options:.mappedIfSafe)`, plane loaded with one `memcpy` into the `NativeArray`. Both fit the ≤ 2 s / 400 MB target with an order of magnitude of headroom.
+
+---
+
+## 6. R5 — Metal backend
+
+Follows the existing Metal layer's conventions exactly (consistency over novelty):
+
+- **Shader**: MSL string `vectorSearchShaders` appended to `MetalShaders.allSource` (SPM runtime-compile path) *and* a `Shaders/VectorSearchShaders.metal` file for the Xcode/metallib path — same dual-mode arrangement as groupBy/merge. Kernel name `swiftpandas_vector_batch_cosine` (library-unique per the request; note it deviates from the layer's bare `snake_case` names deliberately, at the requester's instruction). One thread per candidate row, `if (tid >= n) return;` bounds check, buffers `(query, plane, results, dims, count)`, `.storageModeShared`.
+- **Pipeline**: one more eagerly-created cached `MTLComputePipelineState` in `MetalContext` (matching the existing seven).
+- **Dispatch**: `MetalVectorSearch.swift`, an internal `score(candidates:query:) -> [Float]?` used by the engine. When a mask/nulls exclude rows, the engine gathers a **compacted plane** (candidate rows only) before upload and keeps the `candidateRows` index map — mask-false rows never reach the GPU. When all rows are candidates, the `VectorArray` plane buffer is handed to Metal directly with no copy.
+- **Policy** (in the engine, not in the Metal file — backend *selection* is a search-semantics decision):
+  - `.cpu` — always; the bit-stable documented primary.
+  - `.metal` — `MetalContext.shared == nil` or `SWIFTPANDAS_DISABLE_METAL` ⇒ `throw VectorError.metalUnavailable(reason)`; metric ≠ cosine ⇒ `throw .metalUnsupportedMetric(metric)`. Never a silent fallback. (Note: this is a deliberate departure from the groupBy/merge layer's silent-CPU-fallback philosophy — the request's no-silent-fallback rule is normative for search, and `backendUsed` makes every decision observable.)
+  - `.auto(gpuThreshold:)` — metal iff post-compaction candidate count > threshold AND pipeline available; else cpu. No throw either way; `backendUsed` reports the outcome.
+- GPU emits raw Float cosine scores only; threshold/top-K/tie-break run on the shared CPU steps (§3.2 steps 3–5). Parity contract: ≤ 1e-5 absolute score delta, identical ranking on non-degenerate data; docs state that GPU accumulation order may differ at ulp level and that bit-stability requires `.cpu`.
+
+---
+
+## 7. R7 / A6 — Error model, concurrency, and the switch audit
+
+**`VectorError`** exactly as requested (all eight cases, `CustomStringConvertible`, `Sendable`), in `Vector/VectorError.swift`. Boundary with the existing error enum: *frame-shape* problems keep throwing `DataFrameError` (`similaritySearch(on: "missing")` → `DataFrameError.columnNotFound`, consistent with every other column-resolving API); *vector-semantics* problems throw `VectorError`. One sentence in each public doc comment states which enum can surface.
+
+**Concurrency**: `VectorArray` is a value type over CoW `NativeArray` + `BitVector`, both already `Sendable`; every new public type is `Sendable` by composition, no `@unchecked` anywhere new (the only `@unchecked` stays where it already is, in `ArrayBuffer`/`MetalContext`). `DataFrame`/`Series`/`Column` remain immutable value types; CRUD stays `concat`/`filter`/rebuild.
+
+**A6 audit — the exhaustive edit list** (from a sweep of every `switch`/`guard case` over `Column`/`DTypeEnum`; each site handles `.floatVector` explicitly, no `default:`):
+
+| File | Sites |
+|---|---|
+| `Core/Array/Column.swift` | `count, dtype, isNumeric, validCount, naCount, isNA, nbytes, formattedValue, value(at:), asDouble (→ nil), take(indices:), take(mask:), copy, sum/mean/std/min/max (→ throw path), description, ==` |
+| `Series/Series.swift` | arithmetic/comparison ops, `apply/map/cumsum/unique/nUnique/valueCounts/median/quantile/describe/sortValues`, printing |
+| `DataFrame/DataFrame.swift` | `sortValues` SortKey (702), `concat` (1097), `merge` typed join + payload (1206), groupBy `fastAggregate`/key coding (1527), row description (1897) |
+| `DataFrame/DataFrame+JoinIndex.swift` | `joinKeyText` (102) |
+| `IO/CSV/CSVReader.swift` | writer (1130); `CSVReaderStrict` targets untouched (no vector contract target in v1) |
+| `IO/JSON/JSONReader.swift` | writer pre-check (reject vector columns) |
+| `Metal/MetalGroupBy.swift` | `factorizeGroupColumns` (352) → `unsupportedOperation` as a group key |
+| `Lazy/Predicate.swift` | predicate evaluation → `unsupportedOperation` |
+
+Enforcement: where a `switch` is currently exhaustive without `default`, the compiler *is* the audit — adding the case breaks the build until every site chooses a behavior. For the handful of `guard case .double` fast-path sites, the PR checklist item is a `grep -n 'case .double' Sources | review` pass recorded in the PR description. A CI grep asserting no `default:` appears in any `switch` over `Column` is added to `scripts/`.
+
+---
+
+## 8. Testing & acceptance mapping
+
+XCTest (house convention; no swift-testing). New files under `Tests/SwiftPandasTests/`:
+
+| File | Covers |
+|---|---|
+| `VectorColumnTests.swift` | R1: construction, dims validation, nulls/zero-fill invariant, accessors, `withUnsafeVectorPlane` zero-copy (pointer-identity assertion), dtype string `"floatVector(1024)"` |
+| `VectorOpsMatrixTests.swift` | **A5**: every MUST-work op on a mixed scalar+vector frame; every MUST-throw op asserted to throw `unsupportedOperation`. **A1** norm/normalize edge cases (zero vectors) |
+| `VectorSearchTests.swift` | **A1** numeric pins (identical → exactly 1.0, orthogonal → 0.0, opposite → −1.0, zero-norm → 0.0; per-metric threshold direction); **A2** determinism (repeated searches byte-equal via `[Double]` bit patterns; tie-break with deliberately duplicated vectors); batch ≡ sequential; mask/null exclusion; empty-result correctness (0 survivors is a valid, non-error outcome) |
+| `SPBTests.swift` | **A4**: round-trip losslessness all 5 dtypes × null patterns (incl. empty string vs null string), double-write byte-identity (`Data ==`), corrupt/truncated/tail-bit/oversized-length/future-version files each throwing with a readable reason |
+| `MetalVectorSearchTests.swift` | **A3**: CPU↔GPU ≤ 1e-5 / identical ranking on seeded 10K × 512; `.metal` without a device asserts the **throw** (via `SWIFTPANDAS_DISABLE_METAL=1`, so the assertion runs even on GPU hosts — never a silent skip); `.auto` threshold crossover observable via `backendUsed` |
+| `BenchmarkTests.swift` (extended) | R8 indicative targets: 100K × 1024 cosine CPU/Metal, `fromVectors`, SPB write/read — LCG-seeded, min-of-3, matching the existing benchmark harness |
+
+Determinism tests compare `score.bitPattern`, not `==`, so `-0.0`/NaN drift cannot pass silently.
+
+---
+
+## 9. Delivery plan
+
+Milestones are abstractions, each independently shippable and reviewable:
+
+1. **M1 — storage**: `VectorArray`, `Column.floatVector`, `DTypeEnum.floatVector(dims:)`, the full A6 switch sweep, ops matrix (§4), `VectorColumnTests` + `VectorOpsMatrixTests`. *(The breaking sweep lands first and alone — every later milestone is additive.)*
+2. **M2 — CPU search**: `VectorOps`, engine + public API, bit-parity scorer, A1/A2 tests.
+3. **M3 — SPB**: format/writer/reader/cursor, A4 tests.
+4. **M4 — Metal**: kernel, pipeline, `.metal`/`.auto` policy, A3 tests.
+5. **M5 — release**: benchmarks vs R8 targets, docs (README + a `docs/vectors.md` usage page pinning the euclidean float-order and the bit-stability statement), `SwiftPandasInfo.version = "0.8.0"`, tag, XCFramework rebuild (the `Package.swift` binary pin is stale at v0.6.1-beta and must be bumped regardless).
+
+### Deviations from the request (for Kiraa sign-off)
+
+1. **Version: 0.8.0, not 0.7.0** — 0.7.0-beta already shipped as the hot-cache release.
+2. **Implicit all-numeric sweeps skip vector columns** (like strings today); the `unsupportedOperation` throw fires on explicit aggregation of a vector column (§4).
+3. **JSON writer rejects vector frames** (the request is silent on JSON; leaving the generic path would serialize vectors through an unspecified, untested text format).
+4. **`similaritySearch` on a missing column throws `DataFrameError.columnNotFound`**, not a `VectorError` — consistency with every existing column-resolving API.
+
+Everything else — bit-parity order, SPB byte layout, no-silent-fallback backend policy, error cases, Sendable surface, non-goals — is implemented exactly as written in the request.

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -1,0 +1,167 @@
+# Vector Columns & Similarity Search (v0.8.0)
+
+SwiftPandas 0.8.0 adds first-class vector-database functionality: a Float32
+vector column type, deterministic top-K similarity search (CPU + Metal), and
+the byte-deterministic **SPB** binary format. The design spec lives in
+[vector-spec.md](vector-spec.md); this page is the usage reference and the
+home of the normative numeric contracts.
+
+## Quick start
+
+```swift
+import SwiftPandas
+
+// A vector collection is just a DataFrame: id + metadata + vector column.
+let df = DataFrame(columns: [
+    ("id", .fromInts([1, 2, 3])),
+    ("title", .fromStrings(["intro", "setup", "faq"])),
+    ("embedding", try .fromVectors(embeddings, dims: 1024)),  // [[Float]]
+])
+
+// CRUD stays the immutable idiom:
+let inserted = DataFrame.concat([df, newRows])      // insert
+let deleted  = df.filter(mask: keepMask)            // delete
+                                                    // update = rebuild/merge
+
+// Top-K search (CPU by default — the bit-stable path).
+var options = SearchOptions()
+options.topK = 10
+options.threshold = 0.75                            // cosine: keep score >= 0.75
+let result = try df.similaritySearch(on: "embedding", query: queryVector, options: options)
+result.frame        // matching rows + "__score" column, ranked best-first
+result.backendUsed  // "cpu-vdsp" | "metal" — never silent
+
+// Durable IO (CSV/JSON reject vector frames; SPB is the vector format).
+try df.writeSPB(to: url)
+let restored = try DataFrame.readSPB(from: url)
+```
+
+## The vector column
+
+- `Column.floatVector` stores one flat, contiguous, row-major Float32 plane
+  (`count × dims`) plus a validity bitmap — never array-of-arrays. Null rows
+  are zero-filled (normative: it makes SPB bytes deterministic).
+- `dims` is part of the dtype identity: `df.dtypes` reports
+  `floatVector(1024)`, and columns of different dims never compare equal.
+- Construction: `Column.fromVectors(_:dims:)`,
+  `Column.fromOptionalVectors(_:dims:)`, `Series(vectors:dims:name:)`.
+  Mismatched element counts throw `VectorError.dimensionMismatch`.
+- Access: `series.vectorDims` (nil probe), `series.vector(at:)`,
+  `series.vectors()`, and zero-copy `series.withUnsafeVectorPlane { plane, dims in ... }`.
+- **Storage always holds raw vectors.** `normalizedL2()` is the only
+  normalizer and always returns a new series; construction, IO, and search
+  never normalize implicitly.
+
+### Ops matrix
+
+Carried through correctly: `filter(mask:)`, `takeRows`, `iloc`, `select`,
+`drop`, `rename`, `head`/`tail`, `concat` (same-named vector columns must
+share dims), `merge` (vectors pass through as payload), `estimatedBytes`,
+`describe` (count/nulls/dims only).
+
+Rejected: CSV/JSON serialization of vector frames (throwing entry points
+throw `VectorError.unsupportedOperation`; `select`/`drop` the vector column
+first as the escape hatch), vector columns as merge join keys or groupBy
+keys, and scalar aggregations (skipped exactly as string columns are).
+
+## Similarity search
+
+`SearchOptions`: `metric` (`.cosine` default, `.dot`, `.euclidean`), `topK`
+(> 0), `threshold` (cosine/dot keep `score >= t`; euclidean keep
+`distance <= t`), `mask` (candidate pre-filter, length = rowCount), `backend`.
+
+Semantics (all backends):
+
+- Null vector rows and mask-false rows are excluded **before** scoring.
+- Ranking is fully deterministic: primary by score in metric direction,
+  ties broken by source row index ascending. `topK` truncates after
+  threshold filtering.
+- `similaritySearchBatch` is semantically identical to N sequential calls.
+- An empty result is a valid outcome, not an error; every *misuse* throws a
+  typed `VectorError` (or `DataFrameError.columnNotFound` for a missing
+  column name).
+
+### The numeric contract (normative)
+
+Consumers may pin **bit-identical** scores on the CPU backend
+(`backendUsed == "cpu-vdsp"`). The pinned Float32 order:
+
+- **cosine**:
+  1. `dot = vDSP_dotpr(query, candidate)` (Float)
+  2. `nQ = vDSP_dotpr(query, query)`; `nC` = the per-row squared-norm cache
+     computed at construction (bit-identical to on-the-fly `vDSP_dotpr(v, v)`)
+  3. `denom = sqrt(nQ) * sqrt(nC)` (Float sqrts, Float multiply)
+  4. `denom == 0 → score = 0.0`; else `score = Double(dot / denom)`
+     (Float divide, then widen)
+- **dot**: `score = Double(vDSP_dotpr(q, c))`
+- **euclidean** (pinned float-order): `score = Double(sqrt(vDSP_distancesq(q, c)))`
+  — the sqrt is applied in Float32, then widened.
+
+No Double accumulation, no fused rearrangement, no epsilon guards.
+
+Notes on the pins:
+
+- "Identical vectors score exactly 1.0" holds under this order when the
+  squared norm has an exact Float sqrt (e.g. `[3, 4]` → 25 → 5). For general
+  vectors, `sqrt(n)²` may round one ulp away (e.g. `[1, 2, 3]` scores
+  0.99999994) — the pinned order deliberately does not fudge this back.
+- The vDSP pin holds on Apple platforms (`ACCELERATE_AVAILABLE`). Non-Apple
+  builds use in-order scalar Float32 fallbacks: deterministic per platform,
+  but not bit-identical across platforms.
+
+### Backends
+
+- `.cpu` — always available; the documented primary and the only bit-stable
+  path.
+- `.metal` — GPU batch cosine (**cosine-only in v1**; `.dot`/`.euclidean`
+  throw `metalUnsupportedMetric`). Throws `metalUnavailable` when the
+  device/pipeline is unusable (including `SWIFTPANDAS_DISABLE_METAL=1`).
+  **Never falls back silently.** GPU scores agree with CPU within 1e-5
+  absolute with identical ranking on non-degenerate data; GPU fma
+  accumulation order may differ at ulp level.
+- `.auto(gpuThreshold: 16_384)` — metal iff post-mask candidate count exceeds
+  the threshold AND the pipeline is available; else cpu. Observable via
+  `SearchResultFrame.backendUsed`.
+
+Threshold/topK/tie-break always run on the CPU after the GPU score pass, so
+ranking semantics exist in exactly one place.
+
+## SPB binary format
+
+`writeSPB(to:)` / `readSPB(from:)` — little-endian, magic `"SPB1"`,
+formatVersion 1. Layout and canonical-form rules are documented in
+`Sources/SwiftPandas/IO/SPB/SPBFormat.swift`.
+
+- **Byte-deterministic**: two writes of equal frames are byte-identical (no
+  timestamps, columnNames-ordered, null slots zeroed). Read→write is also
+  byte-stable.
+- **No partial loads**: every validation failure (bad magic, truncation,
+  length overflow, bitmap tail bits, non-canonical null slots) throws
+  `VectorError.corrupt(reason:)` before a DataFrame exists; files newer than
+  version 1 throw `versionUnsupported`.
+- Lossless for all five dtypes including null patterns; a null string and an
+  empty string are distinguished by the validity bitmap.
+
+## Performance (Apple Silicon, 100K × 1024 Float32 ≈ 400 MB)
+
+Measured by `BenchmarkTests.testVA_VectorSearch` (best-of-N, `-O`):
+
+| Operation | Target (indicative) | Measured (M-series) |
+|---|---|---|
+| cosine topK=10, CPU | ≤ 150 ms | ~13 ms |
+| cosine topK=10, Metal (incl. transfer) | ≤ 30 ms | ~42 ms |
+| `fromVectors` | ≤ 500 ms | ~60 ms |
+| `writeSPB` | ≤ 2 s | ~0.5 s |
+| `readSPB` | ≤ 2 s | ~0.1 s |
+
+The Metal path is dominated by the one-time ~400 MB plane upload per call
+(shared-memory copy); at this scale the vDSP CPU path is faster, which is why
+`.cpu` is the default and `.auto` only offloads above a candidate threshold.
+Searches perform no hidden copies: scoring walks the stored plane via the
+zero-copy accessor.
+
+## Non-goals (v1)
+
+ANN indexes (the `SearchBackend` enum and SPB's version field leave room),
+CSV/JSON vector serialization, GPU dot/euclidean, Float64/Float16 storage,
+ragged/sparse vectors, mutable row-level APIs.


### PR DESCRIPTION
## Summary

Implements the Kiraa Engine vector-database requirements (R1–R8, A1–A6) inside SwiftPandas, per the design specification in `docs/vector-spec.md`. Ships as **0.8.0-beta** — the requirements doc targeted 0.7.0, but that number was already taken by the hot-cache release.

### R1 — Vector column type
- `VectorArray`: flat, contiguous, row-major Float32 plane + `BitVector` validity bitmap + a construction-time squared-norm cache (permitted by the bit-parity clause). Null rows are zero-filled (normative, for SPB byte determinism).
- New `Column.floatVector` case; `DTypeEnum.floatVector(dims:)` carries dims as part of type identity — `df.dtypes` reports `floatVector(1024)` and different-dims columns never compare equal.
- Full exhaustive-switch sweep (A6): compiler-forced sites handled explicitly; silent-corruption sites (vector as merge join key, groupBy key, CSV writer) reject explicitly instead of misbehaving.

### R2/R3 — Ops & similarity search
- `l2Norms()` / `normalizedL2()`; storage always holds raw vectors — nothing normalizes implicitly.
- `similaritySearch` / `similaritySearchBatch`: cosine/dot/euclidean, per-metric threshold, mask pre-filter, fully deterministic ranking (score, then source-row tie-break). One internal engine owns compaction → scoring → threshold → topK for every backend.
- **Bit-parity contract**: the CPU scorer pins the exact §4.2 Float32 vDSP order (`vDSP_dotpr` → Float sqrts → Float multiply → Float divide → widen; zero-denominator → 0.0). Determinism tests compare `Double.bitPattern`.

### R5 — Metal
- `swiftpandas_vector_batch_cosine` kernel (embedded MSL + `.metal` twin for Xcode builds); eighth cached pipeline in `MetalContext`.
- `.metal` throws `metalUnavailable` / `metalUnsupportedMetric` — never a silent fallback; `.auto(gpuThreshold:)` decisions observable via `SearchResultFrame.backendUsed`.
- CPU↔GPU parity verified at 10K×512: ≤ 1e-5 score delta, identical ranking.

### R6 — SPB binary format
- `writeSPB`/`readSPB`: little-endian, magic `SPB1`, version 1. Byte-deterministic (double-write and read→write byte-identity tested); bounds-checked cursor reader, **no partial loads**; corrupt/truncated/future-version files throw with human-readable reasons.

### R7/R8
- Typed `VectorError` (8 cases); all new public types `Sendable`; frames stay immutable value types.
- Benchmarks (100K × 1024 ≈ 400 MB, M-series): cosine topK=10 CPU **~13 ms** (target ≤150), Metal ~42 ms (indicative target 30 — dominated by the 400 MB upload; documented), `fromVectors` ~60 ms, `writeSPB` ~0.5 s, `readSPB` ~0.1 s.

## Deviations flagged for consumer sign-off (`docs/vectors.md`)
1. Version is 0.8.0-beta, not 0.7.0 (already shipped).
2. Implicit all-numeric sweeps (`df.describe()`) skip vector columns like strings; the `unsupportedOperation` throw fires on explicit vector aggregation.
3. JSON writers reject vector frames (request was silent on JSON).
4. Missing column names throw `DataFrameError.columnNotFound` (consistency with existing APIs).
5. A1's "identical vectors = exactly 1.0" holds under the normative §4.2 float order when norm² has an exact Float sqrt; general vectors may sit one ulp off (e.g. 0.99999994) — the pinned order deliberately does not fudge this.

## Testing
- 59 new tests across `VectorColumnTests`, `VectorOpsMatrixTests` (A5), `VectorSearchTests` (A1/A2), `SPBTests` (A4), `MetalVectorSearchTests` (A3, incl. forced-disable throw assertion).
- Full suite: **563 tests, 0 failures**, including `SWIFTPANDAS_DISABLE_METAL=1` run.

Remaining release chores (not in this PR): tag `v0.8.0-beta` and rebuild/bump the XCFramework binary pin (still at v0.6.1-beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)