### PR TITLE
v0.8.0-beta release consistency: checksum pin + README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let useBinary = ProcessInfo.processInfo.environment["SWIFTPANDAS_USE_BINARY"] ==
 // checksum after building, and the asset must be uploaded to the matching
 // GitHub release before consumers can resolve the binary target.
 let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.0-beta/SwiftPandas.xcframework.zip"
-let xcframeworkChecksum = "86efd4f87d788523d8b9a474e8d6a7059bec52174f56113945ec3ede1085e3c2"
+let xcframeworkChecksum = "541944efb7a68252f77de8e1dbd477bc138da1396caef969ebf0656c2c54a14b"
 
 // ── Source-mode targets ──
 let sourceTargets: [Target] = [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="swift_pandas.png" alt="SwiftPandas" width="400">
 </p>
 
-# SwiftPandas v0.7.0-beta
+# SwiftPandas v0.8.0-beta
 
 > **BETA RELEASE** — This library is under active development and testing. APIs may change between releases. We welcome bug reports and feedback via [GitHub Issues](https://github.com/kiraa-ai/kiraa-swift-pandas/issues).
 
@@ -13,6 +13,31 @@ SwiftPandas provides `DataFrame`, `Series`, and `Index` types for tabular data m
 The `swiftpandas` CLI ships a **resident-memory daemon mode** (`swiftpandas server start`) that lets multiple shell invocations share an in-memory `DataFrameRegistry`, so a load-once → many-pipes workflow is sub-15 ms per transform vs Python pandas's ~650 ms per-invocation cold-start tax. See [docs/SERVER.md](docs/SERVER.md) and the [examples/cli/](examples/cli/) directory for the full surface.
 
 **Want to try it for yourself?** [docs/TUTORIAL.md](docs/TUTORIAL.md) walks you through a complete analytics workflow twice — first in Python with pandas, then in `swiftpandas` running as a Homebrew-installed daemon. Same dataset, same operations, side-by-side timings. ~20 minutes start to finish.
+
+## What's new in v0.8.0-beta
+
+The **vector release**: first-class vector-database functionality in the DataFrame idiom — a Float32 vector column type, deterministic top-K similarity search (CPU + Metal), and a byte-deterministic binary format. A DataFrame is now a complete vector collection: id column + metadata columns + vector column, with CRUD via the existing immutable idiom (`concat` to insert, `filter(mask:)` to delete, rebuild/`merge` to update). Usage guide: **[docs/vectors.md](docs/vectors.md)**; design spec: [docs/vector-spec.md](docs/vector-spec.md).
+
+- **`Column.floatVector` / `VectorArray`** — fixed-dims Float32 vectors stored as one flat, contiguous, row-major plane plus a validity bitmap (never array-of-arrays). `dims` is part of the dtype identity: `df.dtypes` reports `floatVector(1024)`. Zero-copy plane access for compute kernels via `series.withUnsafeVectorPlane`.
+
+  ```swift
+  let df = DataFrame(columns: [
+      ("id", .fromInts([1, 2, 3])),
+      ("title", .fromStrings(["intro", "setup", "faq"])),
+      ("embedding", try .fromVectors(embeddings, dims: 1024)),
+  ])
+  var options = SearchOptions()
+  options.topK = 10
+  let hits = try df.similaritySearch(on: "embedding", query: queryVector, options: options)
+  hits.frame        // matching rows + "__score", ranked best-first
+  hits.backendUsed  // "cpu-vdsp" | "metal" — never silent
+  ```
+
+- **Similarity search** — `similaritySearch` / `similaritySearchBatch` with cosine / dot / euclidean metrics, per-metric thresholds, candidate mask pre-filtering, and fully deterministic ranking (score, then source-row tie-break). The CPU backend pins an exact Float32 vDSP order so consumers can rely on **bit-identical scores** run-to-run; ~13 ms for topK=10 over 100K × 1024-dim vectors on Apple Silicon.
+- **Metal batch-cosine backend** — `swiftpandas_vector_batch_cosine` kernel; `.metal` throws when unusable (never a silent fallback), `.auto(gpuThreshold:)` decisions are observable via `backendUsed`; CPU↔GPU agreement ≤ 1e-5 with identical ranking.
+- **SPB binary format** — `writeSPB(to:)` / `readSPB(from:)`: little-endian, magic `SPB1`, byte-deterministic (equal frames → byte-identical files), lossless for all five dtypes including null patterns, bounds-checked reader with **no partial loads**. CSV/JSON deliberately reject vector frames; SPB is the durable format (~0.5 s write / ~0.1 s read for a 400 MB frame).
+- **Vector ops** — `l2Norms()`, `normalizedL2()` (the only normalizer — storage always holds raw vectors), `describe()` on vector series reports count/nulls/dims.
+- **Typed `VectorError`** — every misuse throws a described, `Sendable` error (`dimensionMismatch`, `maskLengthMismatch`, `unsupportedOperation`, `metalUnavailable`, `corrupt`, ...); nothing returns an empty result on invalid input.
 
 ## What's new in v0.7.0-beta
 
@@ -68,7 +93,7 @@ This library is in **beta** today. The active gap-list between the current state
 - **Real benchmarks page + correctness baseline against pandas** — published numbers + golden-file suite.
 
 Currently green on the fundamentals:
-- 487 tests, all passing; integration tests against the actual `swiftpandas` binary
+- 563 tests, all passing; integration tests against the actual `swiftpandas` binary
 - Expanding test coverage across every subsystem
 - Documenting all public APIs with comprehensive Swift doc comments
 
@@ -104,8 +129,9 @@ The following vendored C libraries from the pandas project are compiled directly
 - `NullableArray<T>` with `BitVector` validity bitmaps for NA support
 - `NativeArray<T>` with copy-on-write semantics
 - `StringArray` for string data with NA handling
-- `Column` enum for type-erased heterogeneous DataFrame columns (`.double`, `.string`, `.bool`, `.int64`)
-- Full DType hierarchy: `Int8`–`Int64`, `UInt8`–`UInt64`, `Float32`, `Float64`, `Bool`, `String`
+- `Column` enum for type-erased heterogeneous DataFrame columns (`.double`, `.string`, `.bool`, `.int64`, `.floatVector`)
+- `VectorArray` for fixed-dims Float32 vector columns: flat row-major plane + validity bitmap, similarity search (`similaritySearch`, cosine/dot/euclidean, CPU vDSP + Metal), and the byte-deterministic SPB binary format — see [docs/vectors.md](docs/vectors.md)
+- Full DType hierarchy: `Int8`–`Int64`, `UInt8`–`UInt64`, `Float32`, `Float64`, `Bool`, `String`, plus `floatVector(dims:)`
 
 ### Series Operations
 - **Aggregations**: `sum()`, `mean()`, `std()`, `min()`, `max()`, `median()`, `quantile()`, `describe()`, `valueCounts()`
@@ -188,7 +214,7 @@ SwiftPandas supports two SwiftPM consumption modes from a single `Package.swift`
 
 ### Option A — Source build (default)
 
-Add SwiftPandas to your `Package.swift` and pin to the v0.5.0-beta tag (or track `main` for development):
+Add SwiftPandas to your `Package.swift` and pin to the v0.8.0-beta tag (or track `main` for development):
 
 ```swift
 // swift-tools-version: 5.9
@@ -199,7 +225,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     dependencies: [
         // Recommended: pin to a tagged release
-        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.5.0-beta"),
+        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.0-beta"),
 
         // Or track the latest development:
         // .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", branch: "main"),
@@ -231,7 +257,7 @@ SWIFTPANDAS_USE_BINARY=1 swift build
 
 In Xcode, set the environment variable on the scheme (Edit Scheme → Run → Arguments → Environment Variables → `SWIFTPANDAS_USE_BINARY=1`) and re-resolve packages (File → Packages → Reset Package Caches).
 
-The XCFramework bundles three slices (`macos-arm64_x86_64`, `ios-arm64`, `ios-arm64_x86_64-simulator`), is built with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` for module stability, and ships at ~2 MB zipped. SwiftPM downloads, verifies the SHA-256 checksum, and caches it like any other binary target — no `xcodegen`, no C compilation, no Metal preflight.
+The XCFramework bundles three slices (`macos-arm64_x86_64`, `ios-arm64`, `ios-arm64_x86_64-simulator`), is built with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES` for module stability, and ships at ~3 MB zipped. SwiftPM downloads, verifies the SHA-256 checksum, and caches it like any other binary target — no `xcodegen`, no C compilation, no Metal preflight.
 
 > The binary mode trades source debuggability for build speed. If you need to step into SwiftPandas internals (e.g., to investigate behaviour or contribute upstream), unset the env var to fall back to source mode.
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -114,7 +114,7 @@ For projects without a Package manifest — a pure-Xcode app, a workspace, or so
 
 ```bash
 # Latest stable XCFramework as of writing:
-gh release download v0.5.0-beta \
+gh release download v0.8.0-beta \
   --repo kiraa-ai/kiraa-swift-pandas \
   --pattern 'SwiftPandas.xcframework.zip'
 unzip SwiftPandas.xcframework.zip
@@ -123,7 +123,7 @@ unzip SwiftPandas.xcframework.zip
 
 Or download from <https://github.com/kiraa-ai/kiraa-swift-pandas/releases> in the browser.
 
-> **Note**: as of v0.6.1-beta the XCFramework asset is only attached to **v0.5.0-beta** (the most recent release with a published library binary). v0.6.1-beta only ships the CLI ZIP. The next library-binary refresh is tracked in [ROADMAP.md](ROADMAP.md). For now, consume v0.5.0-beta via this path; if you need a more recent binary, use **Path A** with `SWIFTPANDAS_USE_BINARY=1` against an updated tag.
+> **Note**: v0.8.0-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
 
 Move the unzipped `SwiftPandas.xcframework` into your project — somewhere committed-or-not depending on your preference. A common layout:
 
@@ -205,15 +205,15 @@ Each library-binary release requires running `scripts/build-xcframework.sh`. The
 
 ```bash
 # 1. Make sure you're on the tag you want to publish.
-git checkout v0.6.1-beta
+git checkout v0.8.0-beta
 
 # 2. Build, upload to the matching GitHub release, and auto-update
 #    Package.swift's url+checksum constants in one shot.
-scripts/build-xcframework.sh --release-tag v0.6.1-beta --update-package-swift
+scripts/build-xcframework.sh --release-tag v0.8.0-beta --update-package-swift
 
 # 3. Commit and push the Package.swift bump.
 git add Package.swift
-git commit -m "v0.6.1-beta: refresh XCFramework binary"
+git commit -m "v0.8.0-beta: refresh XCFramework binary"
 git push origin main
 
 # 4. Verify binary mode resolves cleanly:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,12 +12,14 @@ Format for each item:
 
 ---
 
-## Where we are today (v0.6.1-beta)
+## Where we are today (v0.8.0-beta)
 
 | Capability | Status |
 |---|---|
 | Pure-Swift DataFrame / Series / Index types | ✅ shipped |
 | Vectorised numeric ops via Apple Accelerate (vDSP) | ✅ shipped |
+| Vector columns (`floatVector`), top-K similarity search (CPU vDSP bit-parity + Metal cosine), see [vectors.md](vectors.md) | ✅ shipped (v0.8.0-beta) |
+| SPB byte-deterministic binary format (`writeSPB`/`readSPB`) | ✅ shipped (v0.8.0-beta) |
 | Metal GPU shaders for groupby + merge | ✅ shipped |
 | Lazy evaluation engine with filter fusion + predicate pushdown + projection pushdown | ✅ shipped |
 | CSV I/O (read + write, custom byte-level parser, default NA handling) | ✅ shipped |

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -491,7 +491,7 @@ The repo ships **twelve** demo scripts under `examples/cli/`, each comparing one
 
 ```bash
 # If you didn't clone the repo, grab them:
-gh release download v0.6.1-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
+gh release download v0.8.0-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
 # Or just `git clone https://github.com/kiraa-ai/kiraa-swift-pandas.git`
 
 # Then:


### PR DESCRIPTION
## Summary

Two fixes that make the published v0.8.0-beta release consumable again:

1. **XCFramework checksum pin** — the release asset was rebuilt (with the PR #16 strip-proof `SwiftPandasInfo.version` fix) after the original upload, but `Package.swift` still pinned the pre-rebuild checksum, so `SWIFTPANDAS_USE_BINARY=1` resolution failed with a checksum mismatch. This adopts the live asset's SHA-256 (`541944ef…`). Verified: `SWIFTPANDAS_USE_BINARY=1 swift package resolve` passes.
2. **README for 0.8.0-beta** (cherry-picked from the release branch — it landed after PR #15 merged): "What's new" section for vector columns / similarity search / SPB, feature-list updates, install pin bumped to `0.8.0-beta`, test count refreshed.

After merge, the `v0.8.0-beta` tag should point at this merge commit so source-pin consumers (`exact: "0.8.0-beta"`) get a manifest whose checksum matches the release asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)