### PR TITLE
fix(BitVector): derive allValid from the bits (#18)

### DIFF
--- a/Sources/SwiftPandas/Core/Array/PandasArray.swift
+++ b/Sources/SwiftPandas/Core/Array/PandasArray.swift
@@ -178,9 +178,9 @@ public protocol PandasArray: CustomStringConvertible {
 public extension PandasArray {
     /// Default implementation: counts the number of `false` entries in ``isNA()``.
     ///
-    /// Concrete types that maintain a precomputed validity count (such as
-    /// ``NullableArray``, which delegates to ``BitVector.popcount``) shadow
-    /// this default with an O(1) property.
+    /// Concrete types backed by a validity bitmap (such as ``NullableArray``,
+    /// which delegates to ``BitVector.popcount``) shadow this default with a
+    /// word-wise popcount: O(*n* / 64) rather than O(*n*).
     var validCount: Int {
         isNA().filter { !$0 }.count
     }

--- a/Sources/SwiftPandas/Core/Array/PandasArray.swift
+++ b/Sources/SwiftPandas/Core/Array/PandasArray.swift
@@ -110,8 +110,8 @@ public protocol PandasArray: CustomStringConvertible {
     /// The number of non-NA (valid) values in this array.
     ///
     /// Default implementation iterates ``isNA()`` and counts `false` entries.
-    /// Concrete types that maintain a precomputed popcount (e.g.,
-    /// ``NullableArray`` via its ``BitVector``) override this for O(1) access.
+    /// Concrete types backed by a validity bitmap (e.g., ``NullableArray``
+    /// via its ``BitVector``) override this with a word-wise popcount.
     var validCount: Int { get }
 
     /// Return a deep (independent) copy of this array.

--- a/Sources/SwiftPandas/Core/Missing/BitVector.swift
+++ b/Sources/SwiftPandas/Core/Missing/BitVector.swift
@@ -91,17 +91,6 @@ public struct BitVector: Sendable, Equatable {
     /// in the last word.
     public private(set) var bitCount: Int
 
-    /// A cached optimization flag indicating whether all bits are known to be
-    /// set (all valid).
-    ///
-    /// When `true`, callers can skip scanning the `words` array entirely.
-    /// This flag is set to `true` only during construction with
-    /// `repeating: true`; it is conservatively reset to `false` by any
-    /// operation that might introduce a zero bit (e.g., subscript set,
-    /// `append(contentsOf:)`). The flag is **not** automatically re-derived
-    /// after mutations — it is a one-way latch toward `false`.
-    internal var _knownAllValid: Bool
-
     // MARK: - Initializers
 
     /// Creates a `BitVector` with all bits set to the given value.
@@ -118,7 +107,6 @@ public struct BitVector: Sendable, Equatable {
     ///   is allocated and filled in bulk.
     public init(repeating value: Bool, count: Int) {
         self.bitCount = count
-        self._knownAllValid = value
         let wordCount = (count + 63) / 64
         self.words = [UInt64](repeating: value ? ~0 : 0, count: wordCount)
         // Clear trailing bits in the last word if not perfectly aligned
@@ -145,7 +133,6 @@ public struct BitVector: Sendable, Equatable {
     ///   all elements are valid.
     public init(_ bools: [Bool]) {
         self.bitCount = bools.count
-        self._knownAllValid = false
         let wordCount = (bools.count + 63) / 64
         self.words = [UInt64](repeating: 0, count: wordCount)
         for (i, b) in bools.enumerated() where b {
@@ -180,7 +167,6 @@ public struct BitVector: Sendable, Equatable {
         }
         set {
             precondition(index >= 0 && index < bitCount, "Index \(index) out of range")
-            if !newValue { _knownAllValid = false }
             let wordIndex = index / 64
             let bitIndex = index % 64
             if newValue {
@@ -215,13 +201,15 @@ public struct BitVector: Sendable, Equatable {
 
     /// Whether every element is valid (no NAs present).
     ///
-    /// Returns `true` immediately if the `_knownAllValid` cache flag is set;
-    /// otherwise falls back to comparing `popcount == bitCount`.
+    /// Computed from the words on every call, the same way ``allNA`` and
+    /// ``naCount`` are. There is no cached answer to keep in sync, so this
+    /// property can never disagree with the bits — which matters because
+    /// many fast paths skip reading the bitmap entirely when it is `true`.
     ///
-    /// - Complexity: O(1) when cached, O(*n* / 64) otherwise.
+    /// - Complexity: O(*n* / 64) where *n* is `bitCount` (one hardware
+    ///   popcount per word).
     public var allValid: Bool {
-        if _knownAllValid { return true }
-        return popcount == bitCount
+        popcount == bitCount
     }
 
     /// Whether every element is NA (all bits cleared).
@@ -323,7 +311,6 @@ public struct BitVector: Sendable, Equatable {
     /// - Parameter other: The `BitVector` whose bits will be appended.
     /// - Complexity: O(*m* / 64) where *m* is `other.bitCount`.
     public mutating func append(contentsOf other: BitVector) {
-        _knownAllValid = false
         let oldCount = bitCount
         let newCount = oldCount + other.bitCount
         let newWordCount = (newCount + 63) / 64

--- a/Sources/SwiftPandas/Core/Missing/BitVector.swift
+++ b/Sources/SwiftPandas/Core/Missing/BitVector.swift
@@ -44,11 +44,10 @@
 //   hardware `POPCNT` instruction on x86-64 and `CNT` on ARM64.
 // - **Bitwise AND / OR / NOT** operate on entire 64-bit words, processing
 //   64 elements per CPU instruction.
-// - **`_knownAllValid`** is a cached flag that short-circuits `allValid`
-//   checks without scanning the words array. It is conservatively set to
-//   `false` whenever a mutation *might* introduce a zero bit; it is only
-//   set to `true` when the vector is known to be all-ones at construction
-//   time.
+// - **Derived queries** — `popcount`, `naCount`, `allValid`, and `allNA` are
+//   all computed from the words on each call (one hardware popcount per
+//   word). Nothing about the bitmap's contents is cached, so no mutation
+//   path can leave a summary out of sync with the bits.
 //
 // ============================================================================
 
@@ -127,10 +126,9 @@ public struct BitVector: Sendable, Equatable {
     /// - Complexity: O(*n*) where *n* is `bools.count`, since each boolean
     ///   must be individually mapped to its bit position.
     ///
-    /// - Note: The `_knownAllValid` flag is set to `false` regardless of
-    ///   input, because scanning for all-true would cost the same as the
-    ///   construction itself. Use `init(repeating:count:)` when you know
-    ///   all elements are valid.
+    /// - Note: Prefer `init(repeating:count:)` when every element is known to
+    ///   be valid; it fills whole words at once instead of setting bits one
+    ///   at a time.
     public init(_ bools: [Bool]) {
         self.bitCount = bools.count
         let wordCount = (bools.count + 63) / 64
@@ -152,10 +150,9 @@ public struct BitVector: Sendable, Equatable {
     ///
     /// - Returns (get): `true` if the element is valid, `false` if NA.
     ///
-    /// - Behavior (set): Setting to `false` clears the bit and
-    ///   conservatively resets `_knownAllValid` to `false`. Setting to
-    ///   `true` sets the bit but does **not** re-derive `_knownAllValid`
-    ///   (doing so would require an O(*n*) scan).
+    /// - Behavior (set): Setting to `false` clears the bit (marks the element
+    ///   NA); setting to `true` sets it (marks the element valid). No other
+    ///   state is touched.
     ///
     /// - Complexity: O(1) for both get and set.
     public subscript(index: Int) -> Bool {

--- a/Tests/SwiftPandasTests/BitVectorInvariantTests.swift
+++ b/Tests/SwiftPandasTests/BitVectorInvariantTests.swift
@@ -317,8 +317,10 @@ final class BitVectorInvariantTests: XCTestCase {
     /// loop that never looks at the bitmap.
     ///
     /// Grouping by `a` gives one row per group. The group keyed `14.0`
-    /// contains exactly one row, whose `t` is NA — so the mean of `t` for that
-    /// group has no valid inputs and must itself be NA.
+    /// contains exactly one row, whose `t` is NA. The mean of a group with no
+    /// valid inputs is `NaN` (0 / 0, matching pandas). What must not happen is
+    /// the stored placeholder under the NA bit being counted as an input,
+    /// which would yield the placeholder itself (`14.0`) as the mean.
     ///
     /// Guards against the aggregate counting an NA row's stored placeholder
     /// as a real value.
@@ -330,12 +332,17 @@ final class BitVectorInvariantTests: XCTestCase {
         // When: grouped by `a` and averaged. Group keys become index labels.
         let means = df.groupBy("a").mean()
 
-        // Then: the single-row NA group has an NA mean
+        // Then: the single-row NA group has no valid inputs, so its mean is NaN
         let labels = means.indexLabels
         guard let row = labels.firstIndex(where: { Double($0) == naGroupKey }) else {
             return XCTFail("groupBy result has no group keyed \(naGroupKey); labels were \(labels)")
         }
-        XCTAssertNil(doubles(means["t"])[row], "a group whose only row is NA must have an NA mean")
+        let mean = doubles(means["t"])[row]
+        XCTAssertNotEqual(mean, 14.0, "the placeholder under the NA bit must not be counted")
+        guard let meanValue = mean else {
+            return XCTFail("a group with no valid inputs has a NaN mean; got NA instead")
+        }
+        XCTAssertTrue(meanValue.isNaN, "a group with no valid inputs has a NaN mean; got \(meanValue)")
     }
 
     /// The CSV writer uses `allValid` to choose a formatter that never checks

--- a/Tests/SwiftPandasTests/BitVectorInvariantTests.swift
+++ b/Tests/SwiftPandasTests/BitVectorInvariantTests.swift
@@ -318,9 +318,11 @@ final class BitVectorInvariantTests: XCTestCase {
     ///
     /// Grouping by `a` gives one row per group. The group keyed `14.0`
     /// contains exactly one row, whose `t` is NA. The mean of a group with no
-    /// valid inputs is `NaN` (0 / 0, matching pandas). What must not happen is
-    /// the stored placeholder under the NA bit being counted as an input,
-    /// which would yield the placeholder itself (`14.0`) as the mean.
+    /// valid inputs is `NaN`, and in SwiftPandas that `NaN` is a valid value
+    /// rather than an NA — so the assertion requires a non-nil `NaN`, not
+    /// `nil`. What must not happen is the stored placeholder under the NA bit
+    /// being counted as an input, which would yield the placeholder itself
+    /// (`14.0`) as the mean.
     ///
     /// Guards against the aggregate counting an NA row's stored placeholder
     /// as a real value.


### PR DESCRIPTION
Implements Design 1 from #19 (`docs/superpowers/designs/2026-08-21-issue-18-bitvector-allvalid.md`) per the approved plan (`planning/plans/2026-08-21-issue-18-bitvector-allvalid.md`). Targets the design branch so #19 carries design + tests + plan + fix; merge this first, then #19 into `main`.

## Commits
- `fa9b478` fix(BitVector): derive `allValid` from the bits; drop `_knownAllValid` cache — `BitVectorInvariantTests` 13/13 green
- `fa0ef99` docs(BitVector): describe derived queries; remove cache narrative
- `5f78db0` docs(PandasArray): `validCount` on bitmap-backed arrays is O(n/64), not O(1)
- `d008e06` docs: `validCount` protocol note and groupBy-mean test comment describe current behaviour

## Verification
- Full suite: `Executed 576 tests, with 2 failures` — both are the pre-existing `MetalMergeTests` GPU failures already present on `main`.
- Benchmark gate (base `7aceae7` → this branch, min-of-3): `testBB_SeriesArithmetic` −2.5%, `testCB_DataFrameFiltering` +0.10%, `testCC_DataFrameSorting` +0.10%, `testDA_CSVIO` +0.09%.
- `grep -rn _knownAllValid Sources/ Tests/` → empty.
- Final whole-branch review clean after one doc-only fix wave.

## Decisions taken during implementation — please accept or overrule here
1. **Test amendment (behaviour-adjacent).** `test_derivedNA_isExcludedFromGroupByMean` asserted `nil` for the mean of an all-NA group; the library (and pandas) returns `NaN`, as column `b` with a correct mask already did. Amended to assert "non-nil `NaN`, and not the placeholder `14.0`". An implementer change to `GroupBy.fastAggregate` mapping every NaN→NA was reverted as out of scope. Design 1 unaffected.
2. Two final-review doc findings folded into `d008e06` (a second stale "O(1)" note in `PandasArray.swift`; the test comment's "0 / 0, matching pandas").
3. **Parked:** `NullableArray.swift:194–197` and `Column.swift:137–139` still say `validCount` is "effectively O(1)". Recommendation: fold in as one more comments-only commit.
4. **Parked:** early-exit `allValid` for small-k gathers (`head(5)` on huge frames). Recommendation: leave unless profiled.

Closes #18