### PR TITLE
release: v0.8.1-beta

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,8 +55,8 @@ let useBinary = ProcessInfo.processInfo.environment["SWIFTPANDAS_USE_BINARY"] ==
 // every tagged release: scripts/build-xcframework.sh prints the new
 // checksum after building, and the asset must be uploaded to the matching
 // GitHub release before consumers can resolve the binary target.
-let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.0-beta/SwiftPandas.xcframework.zip"
-let xcframeworkChecksum = "541944efb7a68252f77de8e1dbd477bc138da1396caef969ebf0656c2c54a14b"
+let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.1-beta/SwiftPandas.xcframework.zip"
+let xcframeworkChecksum = "f80f450a8f2561f06c7a0bd16b93d3e42544c565f71824fbb0cdd8aeda81ae5f"
 
 // ── Source-mode targets ──
 let sourceTargets: [Target] = [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="swift_pandas.png" alt="SwiftPandas" width="400">
 </p>
 
-# SwiftPandas v0.8.0-beta
+# SwiftPandas v0.8.1-beta
 
 > **BETA RELEASE** — This library is under active development and testing. APIs may change between releases. We welcome bug reports and feedback via [GitHub Issues](https://github.com/kiraa-ai/kiraa-swift-pandas/issues).
 
@@ -13,6 +13,12 @@ SwiftPandas provides `DataFrame`, `Series`, and `Index` types for tabular data m
 The `swiftpandas` CLI ships a **resident-memory daemon mode** (`swiftpandas server start`) that lets multiple shell invocations share an in-memory `DataFrameRegistry`, so a load-once → many-pipes workflow is sub-15 ms per transform vs Python pandas's ~650 ms per-invocation cold-start tax. See [docs/SERVER.md](docs/SERVER.md) and the [examples/cli/](examples/cli/) directory for the full surface.
 
 **Want to try it for yourself?** [docs/TUTORIAL.md](docs/TUTORIAL.md) walks you through a complete analytics workflow twice — first in Python with pandas, then in `swiftpandas` running as a Homebrew-installed daemon. Same dataset, same operations, side-by-side timings. ~20 minutes start to finish.
+
+## What's new in v0.8.1-beta
+
+- **Fix: operator-derived NAs no longer erased** — `BitVector.allValid` is now computed from the bitmap on every call instead of a cached flag. Previously `&` and `~` could leave the cache stale, so a column produced by `+ - * /` against an all-valid operand reported "all valid" while carrying an NA; `sortValues`, boolean filters, `groupBy` aggregates, `toCSV()` and `writeSPB` then surfaced the placeholder value where `nil` belonged. Fixes #18.
+- `BitVector` equality now compares bits and length only, so bitmaps with identical contents are `==` regardless of how they were built.
+- New `BitVectorInvariantTests` pin the invariant end to end. Cost: `allValid` is O(*n* / 64) (one hardware popcount per word); the 1M-row benchmark gate moved ≤0.1%.
 
 ## What's new in v0.8.0-beta
 
@@ -215,7 +221,7 @@ SwiftPandas supports two SwiftPM consumption modes from a single `Package.swift`
 
 ### Option A — Source build (default)
 
-Add SwiftPandas to your `Package.swift` and pin to the v0.8.0-beta tag (or track `main` for development):
+Add SwiftPandas to your `Package.swift` and pin to the v0.8.1-beta tag (or track `main` for development):
 
 ```swift
 // swift-tools-version: 5.9
@@ -226,7 +232,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     dependencies: [
         // Recommended: pin to a tagged release
-        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.0-beta"),
+        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.1-beta"),
 
         // Or track the latest development:
         // .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", branch: "main"),
@@ -431,7 +437,7 @@ JSON format:
 | `-i`, `--input` | Input CSV file path (required in CLI mode) |
 | `-o`, `--output` | Output CSV file path (stdout if omitted) |
 | `-c`, `--chain` | Inline DSL transform chain |
-| `-f`, `--file` | Path to a `.json` transform file |
+| `-f`, `--file` | Path to a transform file: `.json` (structured) or any other extension (plain-text pipe DSL, `#` comments allowed) |
 | `--sep` | Column delimiter (default: `,`) |
 | `--dry-run` | Print schema + parsed chain, no output written |
 | `--verbose` | Detailed step-by-step logging with timing (stderr) |
@@ -531,82 +537,61 @@ Homebrew tap).
 
 ```
 SwiftPandas/
+├── Package.swift                   # SPM manifest (source build by default; SWIFTPANDAS_USE_BINARY=1 → XCFramework)
 ├── project.yml                     # XcodeGen project spec
-├── SwiftPandas.xcodeproj/          # Generated Xcode project
-├── benchmarks/
-│   ├── benchmark_pandas.py         # Python vs Swift side-by-side benchmark suite
-│   ├── run_all.py                  # Run all 30 individual benchmarks
-│   └── tests/                      # 30 individual benchmark scripts (01-30)
+├── SwiftPandas.xcodeproj/          # Generated Xcode project (regenerate with `xcodegen generate`)
 ├── Sources/
 │   ├── CSkipList/                  # C: skiplist for windowed median (-O3)
 │   ├── CKHash/                     # C: klib hash tables (-O3)
 │   ├── CUltraJSON/                 # C: UltraJSON encoder/decoder (-O3)
-│   └── SwiftPandas/
-│       ├── Core/
-│       │   ├── DType/              # Type system (DType protocol + concrete types)
-│       │   ├── Array/              # Array types (NativeArray, NullableArray, StringArray, Column)
-│       │   ├── Missing/            # BitVector validity bitmaps
-│       │   └── Storage/            # CoW buffer management
-│       ├── Index/                  # Index types (RangeIndex, StringIndex, Int64Index)
-│       ├── Series/                 # Series type + arithmetic + comparison + apply
-│       ├── DataFrame/              # DataFrame type with GroupBy, Merge, Concat, DataFrameError
-│       ├── Lazy/                   # Lazy evaluation & query optimization
-│       │   ├── Predicate.swift         # Col, ColumnPredicate expression tree + operators
-│       │   ├── QueryPlan.swift         # Logical query plan (indirect enum)
-│       │   ├── LazyDataFrame.swift     # LazyDataFrame API + LazyGroupBy
-│       │   ├── QueryOptimizer.swift    # 4-pass optimizer (fusion, pushdown, elimination)
-│       │   └── QueryExecutor.swift     # Recursive plan execution via eager DataFrame ops
-│       ├── Metal/                  # Metal GPU compute acceleration
-│       │   ├── Shaders/
-│       │   │   ├── ShaderCommon.h      # MurmurHash3, validity bitmap helpers
-│       │   │   ├── GroupByShaders.metal # 5 GPU kernels: hash_insert, reduce_{sum,min,max,count}
-│       │   │   └── MergeShaders.metal  # 2 GPU kernels: hash_build, hash_probe
-│       │   ├── MetalContext.swift       # Singleton device/queue/library + pipeline cache
-│       │   ├── MetalShaders.swift       # SPM-only: embedded MSL source strings
-│       │   ├── MetalGroupBy.swift       # GPU GroupBy: factorize → hash → reduce
-│       │   ├── MetalMerge.swift         # GPU Merge: co-factorize → hash build → probe
-│       │   └── MetalDispatch.swift      # Threshold-based GPU/CPU routing (≥500K rows)
-│       ├── IO/
-│       │   ├── CSV/                # CSV reader/writer with type inference
-│       │   └── JSON/               # JSON reader/writer (records orientation)
-│       └── Numeric/                # VectorOps with Accelerate support
-├── SwiftPandasApp/                 # macOS demo application (SwiftUI)
+│   ├── SwiftPandas/                # Library target
+│   │   ├── Core/
+│   │   │   ├── DType/              # Type system (PandasDType protocol hierarchy + DTypeEnum)
+│   │   │   ├── Array/              # NativeArray, NullableArray, StringArray, Column, PandasArray
+│   │   │   ├── Missing/            # BitVector validity bitmaps
+│   │   │   └── Storage/            # CoW ArrayBuffer
+│   │   ├── Index/                  # RangeIndex, StringIndex, Int64Index
+│   │   ├── Series/                 # Series type + arithmetic + comparison + apply
+│   │   ├── DataFrame/              # DataFrame, GroupBy, Merge, Concat, join-index utilities,
+│   │   │                           #   memory accounting (estimatedBytes), DataFrameError
+│   │   ├── Vector/                 # VectorArray (.floatVector columns), similarity search, vector ops
+│   │   ├── Lazy/                   # Predicate tree, QueryPlan, LazyDataFrame, QueryOptimizer, QueryExecutor
+│   │   ├── Metal/                  # GPU GroupBy, Merge, vector search; MetalContext + MetalDispatch
+│   │   │   ├── Shaders/            # .metal sources (Xcode builds) + ShaderCommon.h
+│   │   │   └── MetalShaders.swift  # Same MSL as Swift strings (SPM builds) — edit both together
+│   │   ├── IO/
+│   │   │   ├── CSV/                # Two-tier CSV reader, strict/contract reader, streaming, writer
+│   │   │   ├── JSON/               # Records-oriented JSON reader/writer (CUltraJSON-backed)
+│   │   │   └── SPB/                # SwiftPandas Binary format: writer, reader, layout constants
+│   │   ├── HotStore/               # Budgeted, file-stamp-validated hot cache (TextCache + FrameCache)
+│   │   └── Numeric/                # VectorOps with Accelerate (vDSP) support + scalar fallbacks
+│   └── SwiftPandasCLI/             # `swiftpandas` executable target
+│       ├── SwiftPandasCLI.swift        # @main root command (ArgumentParser); `run` is the default
+│       ├── Commands/                   # RunCommand (one-shot), ServerCommands, ClientCommands
+│       ├── DSL/                        # Token, Parser, Operation IR, JSONTransformParser
+│       ├── Transforms/                 # TransformRunner — sequential pipeline executor
+│       ├── Server/                     # Daemon, Client, Transport (Unix socket), Protocol (wire JSON),
+│       │                               #   Registry (actor), Handlers, Paths, PIDFile
+│       └── GUI/                        # SwiftUI GUI mode (--gui)
+├── SwiftPandasApp/                 # macOS SwiftUI demo app (Xcode target only)
 │   ├── SwiftPandasApp.swift        # @main entry point
 │   ├── ContentView.swift           # TabView with 3 demo tabs
-│   └── DemoViews/
-│       ├── DataFrameDemoView.swift # DataFrame creation, filter, sort, aggregate
-│       ├── GroupByDemoView.swift   # GroupBy sum/mean/count/min/max
-│       └── BenchmarkView.swift     # CPU vs GPU benchmark with configurable size
-├── Sources/SwiftPandasCLI/         # CLI executable target
-│   ├── SwiftPandasCLI.swift            # @main entry point (ArgumentParser)
-│   ├── CLIError.swift                  # Descriptive error types
-│   ├── DSL/
-│   │   ├── Token.swift                 # Tokenizer (char-by-char scanner)
-│   │   ├── Operation.swift             # Operation enum (parsed IR)
-│   │   ├── Parser.swift                # Pipe-chained DSL parser
-│   │   └── JSONTransformParser.swift   # Structured JSON transform file parser
-│   ├── Transforms/
-│   │   └── TransformRunner.swift       # Sequential operation pipeline executor
-│   └── GUI/
-│       └── GUIApp.swift                # SwiftUI GUI mode (--gui flag)
-├── examples/
-│   ├── cli/                        # 10 example CLI scripts (01-10)
-│   └── data/                       # Sample data & transform files
+│   └── DemoViews/                  # DataFrameDemoView, GroupByDemoView, BenchmarkView
 ├── Tests/
-│   ├── SwiftPandasTests/           # 229 library tests
-│   │   ├── SwiftPandasTests.swift      # Core unit tests (types, Series, DataFrame, GroupBy, Merge)
-│   │   ├── CSVDataFrameTests.swift     # Comprehensive API documentation & demo tests
-│   │   ├── BenchmarkTests.swift        # Performance benchmarks (Swift vs Python pandas)
-│   │   ├── LazyDataFrameTests.swift    # Lazy evaluation, predicates, optimizer tests
-│   │   ├── MetalTests.swift            # GPU correctness tests (GroupBy, Merge, dispatch)
-│   │   ├── NewFeaturesTests.swift      # Equatable, Sequence, JSON I/O, throwing API tests
-│   │   └── SampleData/employees.csv    # 15-row sample dataset
-│   └── SwiftPandasCLITests/        # 68 CLI tests
-│       ├── ParserTests.swift           # Tokenizer, DSL parser, JSON parser tests
-│       ├── TransformTests.swift        # Transform operation tests
-│       ├── IntegrationTests.swift      # End-to-end pipeline tests
-│       └── Fixtures/                   # Test data (sales.csv, transforms.json)
-└── Package.swift                   # SPM manifest
+│   ├── SwiftPandasTests/           # 377 library tests (16 files) + SampleData/employees.csv
+│   └── SwiftPandasCLITests/        # 186 CLI + daemon tests (15 files) + Fixtures/
+├── benchmarks/
+│   ├── benchmark_pandas.py         # Python vs Swift side-by-side benchmark suite
+│   ├── run_all.py                  # Run all 30 individual benchmarks
+│   └── tests/                      # 30 individual benchmark scripts (01-30)
+├── examples/
+│   ├── cli/                        # 13 example CLI scripts (00-12)
+│   └── data/                       # sales.csv + transforms.json
+├── scripts/
+│   ├── build-xcframework.sh        # Build SwiftPandas.xcframework.zip + print checksum
+│   └── build-release.sh            # Sign, notarize, and publish the CLI (maintainer only)
+└── docs/                           # SERVER.md, INSTALL.md, TUTORIAL.md, ROADMAP.md, vectors.md,
+                                    #   hotstore.md, llm-grammar.md, EMBEDDING.md, HOMEBREW.md, …
 ```
 
 ## Xcode Project Targets
@@ -614,9 +599,10 @@ SwiftPandas/
 | Target | Type | Description |
 |---|---|---|
 | **SwiftPandas** | macOS Framework | Core library with Metal shaders precompiled to `default.metallib` |
+| **SwiftPandas-iOS** | iOS Framework | Same sources built for iphoneos + iphonesimulator |
 | **SwiftPandasApp** | macOS Application | SwiftUI demo app with DataFrame, GroupBy, and Benchmark views |
-| **SwiftPandasTests** | Unit Test Bundle | 229 tests including GPU correctness, lazy evaluation, and performance benchmarks |
-| **SwiftPandasCLITests** | Unit Test Bundle | 68 tests covering DSL parsing, transforms, and end-to-end CLI pipelines |
+| **SwiftPandasCLI** | Command-line tool | The `swiftpandas` binary (one-shot CLI + resident-memory daemon) |
+| **SwiftPandasTests** | Unit Test Bundle | 377 library tests including GPU correctness, lazy evaluation, vectors, SPB, HotStore, and benchmarks |
 
 The project is generated via [XcodeGen](https://github.com/yonaskolb/XcodeGen) from `project.yml`. Build settings:
 
@@ -624,11 +610,13 @@ The project is generated via [XcodeGen](https://github.com/yonaskolb/XcodeGen) f
 - **C libraries**: `-O3` in all configurations
 - **Metal**: Precompiled `.metal` → `default.metallib` at build time
 - **Framework**: `ENABLE_TESTABILITY = YES` in Release for benchmark validation
-- **Deployment target**: macOS 13.0
+- **Deployment target**: macOS 13.0 / iOS 16.0
+
+> **Note:** `SwiftPandasCLITests` is intentionally not an Xcode target — macOS executables don't export symbols for `@testable import`, so the CLI test bundle only links under SwiftPM. Run it with `swift test --filter SwiftPandasCLITests` (see the note at the bottom of `project.yml`).
 
 ## Metal GPU Acceleration
 
-SwiftPandas uses Metal compute shaders to accelerate GroupBy and Merge operations on Apple Silicon. GPU dispatch is transparent — operations automatically use the GPU for datasets ≥ 500K rows and fall back to the CPU for smaller datasets.
+SwiftPandas uses Metal compute shaders to accelerate GroupBy, Merge, and vector similarity search on Apple Silicon. GPU dispatch is transparent — GroupBy and Merge automatically use the GPU above a row-count threshold and fall back to the CPU below it (or whenever the GPU path returns `nil`).
 
 ### Architecture
 
@@ -652,7 +640,7 @@ CPU (Swift)                          GPU (Metal Compute Shaders)
 
 ### Metal Shader Details
 
-**7 GPU Compute Kernels** in 2 shader files:
+**8 GPU compute kernels** in 3 shader files:
 
 #### GroupBy Shaders (`GroupByShaders.metal`)
 - **`groupby_hash_insert`** — Open-addressing hash table maps factorized key codes to group IDs. Uses `atomic_compare_exchange_weak` for thread-safe slot insertion. Spin-waits on group ID write for concurrent readers.
@@ -664,6 +652,9 @@ CPU (Swift)                          GPU (Metal Compute Shaders)
 - **`merge_hash_build`** — Builds hash table from right table's factorized key codes. Duplicate keys are chained via `chain_next` linked list using `atomic_exchange`.
 - **`merge_hash_probe`** — Each left-table thread probes the hash table. Follows `chain_next` chains for duplicate matches. Output pairs are written to global buffers via `atomic_fetch_add` on an output counter.
 
+#### Vector Search Shader (`VectorSearchShaders.metal`)
+- **`swiftpandas_vector_batch_cosine`** — One thread per candidate row of a compacted Float32 plane; emits the raw cosine score per candidate. Threshold, top-K, and tie-break run on the CPU, and results must match the CPU vDSP path to ≤ 1e-5 with identical ranking (see `MetalVectorSearchTests`). Used by `similaritySearch` when the backend is `.metal` or `.auto`.
+
 #### Shared Utilities (`ShaderCommon.h`)
 - **`hash_uint`** / **`hash_int32`** — MurmurHash3-style finalizer for integer hashing
 - **`hash_combine`** — Hash combiner using the golden ratio constant (`0x9e3779b9`)
@@ -674,6 +665,7 @@ CPU (Swift)                          GPU (Metal Compute Shaders)
 
 ```swift
 public enum MetalDispatch {
+    // Overridable at launch via SWIFTPANDAS_GROUPBY_THRESHOLD / SWIFTPANDAS_MERGE_THRESHOLD
     public static var groupByThreshold = 10_000_000
     public static var mergeThreshold   = 500_000
 
@@ -683,58 +675,97 @@ public enum MetalDispatch {
 }
 ```
 
-- **Threshold-based**: CPU fast-path beats GPU for < 500K rows due to dispatch overhead
+- **Threshold-based**: the CPU fast path beats the GPU below the thresholds due to dispatch overhead; both thresholds are settable in code or via environment variable
 - **Automatic fallback**: Returns `nil` if GPU fails → caller uses CPU path
 - **Unified memory**: Apple Silicon shares memory between CPU and GPU — near zero-copy buffer transfers
-- **Pipeline caching**: All 7 compute pipeline states are created once at `MetalContext` initialization
+- **Pipeline caching**: All 8 compute pipeline states are created once at `MetalContext` initialization
 
 ### Xcode vs SPM Shader Loading
 
 | Build System | Shader Loading | Performance |
 |---|---|---|
 | **Xcode** | `.metal` files precompiled to `default.metallib` at build time | Instant load |
-| **SPM** | MSL source strings compiled at runtime via `device.makeLibrary(source:)` | ~100ms first-call overhead |
+| **SPM** | MSL source strings (`MetalShaders.swift`) compiled at runtime via `device.makeLibrary(source:)` | ~100ms first-call overhead |
+
+The two copies of the shader source must be kept in sync — any kernel change goes into both the `.metal` file and the matching string in `MetalShaders.swift`.
 
 ## Testing
 
 ### Running Tests
 
-297 tests across 9 test files. All tests use XCTest.
+563 tests across 31 test files (377 library, 186 CLI + daemon). All tests use XCTest.
 
 ```bash
 # Run all tests (Package.swift applies -O optimization even in debug config)
 swift test
 
-# Run a specific test file
-swift test --filter SwiftPandasTests       # core unit tests
-swift test --filter CSVDataFrameTests      # CSV & API demos
-swift test --filter LazyDataFrameTests     # lazy evaluation engine
-swift test --filter MetalTests             # GPU compute shaders
-swift test --filter BenchmarkTests         # performance benchmarks
-swift test --filter NewFeaturesTests       # Equatable, Sequence, JSON I/O, throwing API
+# Run one test target
+swift test --filter SwiftPandasTests          # library (also matches the SwiftPandasTests class)
+swift test --filter SwiftPandasCLITests       # CLI + daemon
 
-# CLI tests
-swift test --filter ParserTests            # DSL tokenizer & parser
-swift test --filter TransformTests         # transform operations
-swift test --filter IntegrationTests       # end-to-end pipelines
+# Run a specific test class
+swift test --filter LazyDataFrameTests        # lazy evaluation engine
+swift test --filter MetalTests                # GPU compute shaders
+swift test --filter VectorSearchTests         # CPU similarity search
+swift test --filter SPBTests                  # SPB binary format
+swift test --filter HotStore                  # hot cache (HotStoreLifecycle/ByteIdentity/View classes)
+swift test --filter ServerIntegrationTests    # real daemon via the CLI binary
+
+# Run a single test method (Class/method)
+swift test --filter 'SPBTests/test_roundTrip_allDtypes_withNulls'
 ```
 
 > **Note:** Package.swift specifies `-O` (optimized) for both the library and
 > test targets, so `swift test` produces optimized code suitable for benchmarking.
+>
+> The daemon tests (`ForegroundDaemonTests`, `BackgroundDaemonTests`,
+> `ServerIntegrationTests`, `CLISubcommandTests`) exec the real `swiftpandas`
+> binary that `swift test` builds, and isolate themselves from `~/.swiftpandas/`
+> via the `SWIFTPANDAS_RUNTIME_DIR` / `SWIFTPANDAS_SOCK` / `SWIFTPANDAS_PIDFILE`
+> overrides. `MetalTests` expect a Metal-capable Mac.
 
 ### Test Files
 
+**Library (`Tests/SwiftPandasTests`, 377 tests)**
+
 | File | Tests | Coverage |
 |---|---|---|
-| **SwiftPandasTests.swift** | ~90 | Core types (DType, NativeArray, BitVector, NullableArray, StringArray, Column, Index), Series (construction, aggregation, statistics, NA handling, arithmetic, comparison, apply/map, cumsum, unique/duplicated, sorting), DataFrame (construction, column access, row access, loc, filtering, mask subscript, single/multi-column sorting, aggregation, describe, duplicates, concat, rename), GroupBy (single/multi-column), Merge (inner, left), integration workflow |
-| **CSVDataFrameTests.swift** | ~10 | API documentation demos covering Series, DataFrame, GroupBy, Merge, Concat, CSV I/O, Core Types, Index Types, full pipeline; CSV file round-trip |
-| **LazyDataFrameTests.swift** | ~44 | Predicates (comparison, string, AND/OR/NOT), LazyDataFrame ops (filter, select, drop, sort, head, groupBy, merge), chained operations, query optimizer (filter fusion, predicate pushdown, limit elimination, identity select removal), explain output, edge cases (empty, single-row, all-filtered, NA values) |
-| **MetalTests.swift** | ~16 | Metal dispatch threshold logic, GPU GroupBy correctness (sum/mean/count/min/max, large dataset 100K), GPU Merge (inner join, no-matches, duplicate keys, column naming), GPU/CPU integration |
-| **NewFeaturesTests.swift** | ~21 | Equatable conformance (Series, DataFrame, Column), Sequence conformance (Series, DataFrame), JSON I/O (read/write string, path, URL, Data), throwing API, convenience initializers, Bool/Int? Series, fromOptionalInts/fromOptionalBools |
-| **BenchmarkTests.swift** | ~15 | Performance benchmarks at 1M rows: Series aggregation/arithmetic/sorting/statistics, DataFrame construction/filtering/sorting/aggregation, GroupBy, Merge, Concat, CSV I/O, Lazy vs Eager |
-| **ParserTests.swift** | ~37 | CLI: Tokenizer, DSL parser (all 12 operations), arithmetic expression precedence, JSON transform parser, error cases |
-| **TransformTests.swift** | ~21 | CLI: Filter, sort, rename, select, drop, head, tail, round, derive, cast, groupby+agg, chained pipelines |
-| **IntegrationTests.swift** | ~10 | CLI: Full pipeline (inline & JSON), empty results, derive pipeline, verbose mode, JSON error messages, edge cases |
+| **SwiftPandasTests.swift** | 123 | Core types (DType, NativeArray, BitVector, NullableArray, StringArray, Column, Index), Series (construction, aggregation, statistics, NA handling, arithmetic, comparison, apply/map, cumsum, unique/duplicated, sorting), DataFrame (construction, access, loc/iloc, filtering, sorting, aggregation, describe, duplicates, concat, rename), GroupBy, Merge, integration workflow |
+| **LazyDataFrameTests.swift** | 44 | Predicates, LazyDataFrame ops, chained operations, optimizer passes (filter fusion, predicate pushdown, limit elimination, identity-select removal), `explain` output, edge cases |
+| **HotStoreTests.swift** | 25 | Hermetic HotStore tests via an in-memory `FileSystemProbe`: budget/eviction, pinning, stamp validation, publish semantics, stats |
+| **CSVContractTests.swift** | 21 | Contract-driven CSV parsing (strict / allStrings), RFC-4180 `CSVLine` codec, writer quoting modes, streaming row reader |
+| **NewFeaturesTests.swift** | 21 | Equatable/Sequence conformance, JSON I/O, throwing API, convenience initializers, Bool/Int? Series |
+| **VectorSearchTests.swift** | 21 | CPU similarity search: exact numeric pins (bit-parity contract) and determinism |
+| **BenchmarkTests.swift** | 16 | 1M-row benchmarks: Series, DataFrame, GroupBy, Merge, Concat, CSV I/O, Lazy vs Eager |
+| **MetalTests.swift** | 16 | Dispatch thresholds, GPU GroupBy correctness, GPU Merge (inner, no-match, duplicate keys), GPU/CPU integration |
+| **VectorColumnTests.swift** | 16 | `VectorArray` construction and invariants, Column/Series integration, accessors |
+| **VectorOpsMatrixTests.swift** | 16 | Every DataFrame op verified on a mixed scalar+vector frame — supported ops work, unsupported ops throw |
+| **JoinIndexAndMemoryTests.swift** | 15 | Join-index utilities (last-row-wins) and `estimatedBytes` accuracy bound |
+| **SPBTests.swift** | 15 | SPB round-trip losslessness (all 5 dtypes × null patterns), byte-identical double writes, rejection of corrupt/truncated files |
+| **CSVDataFrameTests.swift** | 10 | API documentation demos covering Series, DataFrame, GroupBy, Merge, Concat, CSV I/O; CSV file round-trip |
+| **MetalVectorSearchTests.swift** | 7 | CPU↔Metal score parity (≤ 1e-5, identical ranking), strict `.metal` throw policy, `.auto` fallback |
+| **CSVMappedReadTests.swift** | 6 | Memory-mapped `readCSV(path:)` path (Phase A loader work) |
+| **DataFrameMemoryTests.swift** | 5 | `DataFrame.estimatedBytes` accounting used by the daemon's `list`/`drop` |
+
+**CLI + daemon (`Tests/SwiftPandasCLITests`, 186 tests)**
+
+| File | Tests | Coverage |
+|---|---|---|
+| **ParserTests.swift** | 37 | Tokenizer, DSL parser (all 12 operations), arithmetic expression precedence, JSON transform parser, error cases |
+| **TransformTests.swift** | 21 | Filter, sort, rename, select, drop, head, tail, round, derive, cast, groupby+agg, chained pipelines |
+| **HandlersTests.swift** | 19 | Daemon command handlers end-to-end against an in-process `DataFrameRegistry` |
+| **ProtocolTests.swift** | 13 | Wire-protocol JSON round-trips pinning the request/response schema |
+| **CLISubcommandTests.swift** | 12 | Black-box tests of the `swiftpandas` binary's subcommand surface |
+| **KindTaxonomyTests.swift** | 11 | The `kind` tag (transaction/metadata) across registry and wire protocol |
+| **PIDFileTests.swift** | 11 | `PIDFile` semantics in isolated temp directories |
+| **IntegrationTests.swift** | 10 | One-shot `run` pipelines (inline & JSON), empty results, verbose mode, error messages |
+| **RegistryTests.swift** | 10 | `DataFrameRegistry` actor: bind/lookup/drop/list semantics |
+| **PathsTests.swift** | 9 | Runtime-dir / socket / pid-file resolution and env overrides |
+| **ServerIntegrationTests.swift** | 9 | Entire `server` surface driven through the real CLI binary against a background daemon |
+| **BackgroundDaemonTests.swift** | 8 | `server start` re-exec/`setsid()` spawn path |
+| **ForegroundDaemonTests.swift** | 8 | Foreground daemon driven via the `Client` API |
+| **TransportTests.swift** | 8 | `Transport` over a real `NWListener` on a temp Unix-domain socket |
+
 
 ### Python Benchmarks
 
@@ -884,7 +915,7 @@ Both Swift and Python benchmarks are compiled with full optimizations:
 - [x] Concat with mixed column types
 - [x] Pretty-printed table output with box drawing
 - [x] Performance benchmarks (Swift vs Python pandas)
-- [x] Metal GPU compute shaders for GroupBy and Merge (7 kernels)
+- [x] Metal GPU compute shaders for GroupBy and Merge (7 kernels) plus batch-cosine vector search (8 total)
 - [x] Precompiled Metal shaders via Xcode (`.metal` → `default.metallib`)
 - [x] Python vs Swift side-by-side benchmark suite (`benchmarks/benchmark_pandas.py`)
 - [x] 30 individual detailed benchmark scripts (`benchmarks/tests/`)

--- a/Sources/SwiftPandas/SwiftPandas.swift
+++ b/Sources/SwiftPandas/SwiftPandas.swift
@@ -49,5 +49,5 @@ public enum SwiftPandasInfo {
     /// interface, so clients inline the literal and never need the symbol —
     /// the failure mode is impossible by construction, in any build mode.
     @inlinable
-    public static var version: String { "0.8.0-beta" }
+    public static var version: String { "0.8.1-beta" }
 }

--- a/SwiftPandas.xcodeproj/project.pbxproj
+++ b/SwiftPandas.xcodeproj/project.pbxproj
@@ -8,9 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		0102E1B6637EEA07261D85EB /* HotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB7B7363989C628E7DEB7D /* HotStore.swift */; };
+		012BA7EE8B8853F571E0528B /* VectorSearchShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 60B4097CAF5406D46CADAA9F /* VectorSearchShaders.metal */; };
 		015BD21E1127BEF42E215844 /* NumericDTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34855C4F0B79C939DD409DD8 /* NumericDTypes.swift */; };
 		0181C17DFB7EADFE06FF93C0 /* PandasArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AD38D7ECCD6EE5B8BF2F73 /* PandasArray.swift */; };
 		01FEDECC1810186D0F38DFC9 /* ShaderCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = DCD547CE28268E228BA21D66 /* ShaderCommon.h */; };
+		020AE531981BEBC0DDBA000D /* SPBWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850D9E672AE1D3BFA1E7E1F3 /* SPBWriter.swift */; };
 		07D2DFE099E8B2B0D07279A8 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F951783B44D4F86D221F5EB5 /* Predicate.swift */; };
 		07DE97784FDD40798E6E53A4 /* DataFrameError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1401F868449BF067FB1BE1 /* DataFrameError.swift */; };
 		0CA5DD906683010A97E12CE1 /* PandasArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AD38D7ECCD6EE5B8BF2F73 /* PandasArray.swift */; };
@@ -18,28 +20,37 @@
 		0D7A0049DBF49C7FFC96CBA8 /* khash.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AFA34B68A7B97BF6F7EC370 /* khash.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		0E9A5CA21F70D399F8002F52 /* SwiftPandas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28F3D18AE1E2EE81DE5CB83 /* SwiftPandas.swift */; };
 		0FD353BC50F11AFA45DB69D2 /* VectorOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F30A3C7DB23297D373DBA0 /* VectorOps.swift */; };
+		11A1664593AF23DFB1081FF6 /* VectorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A44B9B2D3345EC176399F8F9 /* VectorError.swift */; };
 		130E265F076756503C4CE0A5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D54DADED754D5BC12DF98593 /* Assets.xcassets */; };
 		13B87867978645B6BB8E7D4E /* employees.csv in Resources */ = {isa = PBXBuildFile; fileRef = 9A99DFCEF5DDD4349827FEF3 /* employees.csv */; };
+		152A2C36E4E5230619CABBDD /* VectorSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F37FC6A89F3FF467732709E /* VectorSearchTests.swift */; };
 		176BE03DA4B4CB9677F56423 /* MetalGroupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9152C67A4012AE1ED95C17D0 /* MetalGroupBy.swift */; };
 		18753325E7B2AE901D00F867 /* Registry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F16E6823D7026563D61A01 /* Registry.swift */; };
 		1A6EE598DFDE0A5A4D39E86B /* DataFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725C3853F05C0920274BF161 /* DataFrame.swift */; };
 		1DE34837FAB9CAF41D7BB2C1 /* LazyDataFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE13536785EE5BFC02BD2E0D /* LazyDataFrameTests.swift */; };
 		1E368632F138FB901490B22C /* QueryExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B4A80FBDBCF0C0B9E3FDDA /* QueryExecutor.swift */; };
+		26A4106B9570C4D57F5AE704 /* VectorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A44B9B2D3345EC176399F8F9 /* VectorError.swift */; };
 		26D497DCD9F61E9EB8125945 /* FrameCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAF54ED5FF37B295D2EC94FE /* FrameCache.swift */; };
 		284A00A652E5D96788830BAF /* CSVLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8367516C42A9B6BF39B6670F /* CSVLine.swift */; };
+		28B012B478C8CC2E465F0B7D /* VectorColumnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DE67160B920ABE30D3E9AD /* VectorColumnTests.swift */; };
 		29B876F3ACF2B56CF5707B69 /* portable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F877B1C6BBEB8C3A073AD2E /* portable.h */; };
+		2AB2299A8DFE96A0E703C273 /* MetalVectorSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C238BF3F664ECAC011A4F2 /* MetalVectorSearch.swift */; };
+		2AE6CDBCF06A41ED64D3292B /* SPBWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850D9E672AE1D3BFA1E7E1F3 /* SPBWriter.swift */; };
 		2CC1F5A12DD2FB33AFF1D307 /* DType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24D37B50C94748102DA0EC9 /* DType.swift */; };
 		2D11886EE9F2D76BB83CA478 /* Column.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8679BEFC622508CAF1EE07 /* Column.swift */; };
 		2F1BAFFF047C36C2B73F40F6 /* CSVReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC07EC065B5C63900D3BF24A /* CSVReader.swift */; };
 		2F83E1ABFEFA6F47DCF7836F /* khash.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AFA34B68A7B97BF6F7EC370 /* khash.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		31EA71E19E92E19E973868FE /* DataFrameDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80ED81B7E4A9A7671F3A5ED /* DataFrameDemoView.swift */; };
 		31F375C6C110E468E0929A08 /* TextCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD462251C90FFD82BE04714D /* TextCache.swift */; };
+		328DB4501CCFF0C4401553C2 /* VectorOpsMatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2FBF2E5C3601D28C2E1080 /* VectorOpsMatrixTests.swift */; };
 		32F7E1188305E2DBE1B68309 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C63CA072F41616045F85D2 /* Token.swift */; };
 		34129D1A378E55C954EE9A01 /* skiplist.h in Headers */ = {isa = PBXBuildFile; fileRef = 755EA62922A9F0EB0A476736 /* skiplist.h */; };
 		34F6A6EEE4F70A80DCDE9701 /* QueryOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0B19D5EA718C085C27AB2A /* QueryOptimizer.swift */; };
+		3585A5214089DFD0319B0C96 /* VectorArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3B60D77C618C75E34E2B0D /* VectorArray.swift */; };
 		382E4C7DB3EAEAD28466C7AD /* DataFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725C3853F05C0920274BF161 /* DataFrame.swift */; };
 		38934C4ACB339F9B15DF5B66 /* skiplist.c in Sources */ = {isa = PBXBuildFile; fileRef = A9B9154E503F8C0AF170E60A /* skiplist.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		3B731C9EE18D7CF9B53C3931 /* SwiftPandasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1B757A00691EEC78E36F9F /* SwiftPandasApp.swift */; };
+		3BE2BB39CD5D2B9C8DB20C03 /* VectorArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3B60D77C618C75E34E2B0D /* VectorArray.swift */; };
 		46FCE5E338E44542C629FB93 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9957741BCE97B414826DCE85 /* Parser.swift */; };
 		49607F913D7D582D19952FD8 /* ClientCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3AE7F83FF3067EDC7E12DB /* ClientCommands.swift */; };
 		4965441BA87D882E5AF58F35 /* MetalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408C06FD62F2C489D8DB191B /* MetalContext.swift */; };
@@ -67,6 +78,7 @@
 		7708CE8FA8C9593365A8CC1C /* QueryPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1194ED9E8BDF89558FD6968 /* QueryPlan.swift */; };
 		7814EC209B984E84282B4F52 /* NullableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CE8C7146A7AE19A13AE2B4 /* NullableArray.swift */; };
 		789C0EBEF45CDFC8C3CA059B /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7464B03A7DE52D165D759490 /* Buffer.swift */; };
+		795BAD065F6D88035B9B6A5A /* BitVectorInvariantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9260936CC73E2357A37194C2 /* BitVectorInvariantTests.swift */; };
 		79D5976E2B2E3D00DC865719 /* Daemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F32C7C94134212AA97B6684 /* Daemon.swift */; };
 		7B12FB5FA55C994067F68B82 /* NewFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B0C44E96FFC94F7C320429 /* NewFeaturesTests.swift */; };
 		7BD6D351001680F45CBB3A62 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2181EEE84B163800594FA046 /* Protocol.swift */; };
@@ -77,6 +89,7 @@
 		7EF37AC6641843463C3830DB /* DataFrame+JoinIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E362A4F7A7B77E8B4041DE0 /* DataFrame+JoinIndex.swift */; };
 		7FEF626BAC520560054A9A6F /* ultrajsonenc.c in Sources */ = {isa = PBXBuildFile; fileRef = E744C27B54AFC8DCB62CA803 /* ultrajsonenc.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		813204040C870C78C04BD299 /* DataFrameError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1401F868449BF067FB1BE1 /* DataFrameError.swift */; };
+		82A3E79B5FDE8AEDD4728A00 /* VectorSeriesOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C85A6772EEDDA425BF75C4 /* VectorSeriesOps.swift */; };
 		837D57E390A3B5D9CA75CB7B /* BenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4460308C3F8C76BC0CF03DD7 /* BenchmarkTests.swift */; };
 		8414785F8100B4AC5EE720B4 /* ServerCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4345391C8274CA47124D5F /* ServerCommands.swift */; };
 		84F60AFAB78AC00365E40986 /* VectorOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F30A3C7DB23297D373DBA0 /* VectorOps.swift */; };
@@ -102,14 +115,18 @@
 		9F160490346220C53E1D54EC /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081080B40C197B1CD08C875C /* Style.swift */; };
 		9F64D3A8DFB9657BF5503015 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8125BF0E9BBF9363E7E6098 /* Operation.swift */; };
 		9FB53F9EC567895D7126CABC /* QueryPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1194ED9E8BDF89558FD6968 /* QueryPlan.swift */; };
+		A066E7527EDCF15ED6946EC5 /* SPBTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8217FE89128CBAA23D3EE86 /* SPBTests.swift */; };
 		A40B773439A18810B9480637 /* CLIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B723F0FB414EF1DB0930CEF4 /* CLIError.swift */; };
 		A4778E53906B16B9D3254DD6 /* HotStoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54D6E77C32787D67DA7B197 /* HotStoreTypes.swift */; };
 		A51F7D1708A84EF637FEDDD4 /* skiplist.h in Headers */ = {isa = PBXBuildFile; fileRef = 755EA62922A9F0EB0A476736 /* skiplist.h */; };
+		A8E079E7465CE901D2880990 /* VectorSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598A8FF2F271D8A38F008042 /* VectorSearch.swift */; };
+		AA3BE1D3BBFF86CDE1DF379B /* VectorSeriesOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C85A6772EEDDA425BF75C4 /* VectorSeriesOps.swift */; };
 		AA604D56C8049D00A21D6E28 /* MetalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408C06FD62F2C489D8DB191B /* MetalContext.swift */; };
 		AA9506361F2B946998AB0ED0 /* BitVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD9E552B3EE0341E8D16FBD /* BitVector.swift */; };
 		AD5E262AF749D75CC92FB2F0 /* portable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F877B1C6BBEB8C3A073AD2E /* portable.h */; };
 		AF2355AF88A16ECB6FE07AD9 /* HotBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7480C261911A192425CBE82D /* HotBudget.swift */; };
 		AF9FF06D8095079569F31D24 /* JoinIndexAndMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956B46CC7F17CE58186D668F /* JoinIndexAndMemoryTests.swift */; };
+		AFF6F64F0DB36E7B3B798F23 /* MetalVectorSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C238BF3F664ECAC011A4F2 /* MetalVectorSearch.swift */; };
 		B09AABE6C2E0B1E4B3E8CABC /* Series.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BC5D47091871B54416C613 /* Series.swift */; };
 		B12C69A6B3B63776C3281563 /* TextCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD462251C90FFD82BE04714D /* TextCache.swift */; };
 		B433902F318B689A03D2288E /* ultrajsonenc.c in Sources */ = {isa = PBXBuildFile; fileRef = E744C27B54AFC8DCB62CA803 /* ultrajsonenc.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
@@ -119,6 +136,7 @@
 		BEE266871A10CC5DBC38ED4D /* Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423F4EFB71BB9E23C8A4AA59 /* Index.swift */; };
 		BF5C02E03467964E891D2873 /* DataFrameMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFE849A42B05EAE9DA9B79F /* DataFrameMemoryTests.swift */; };
 		C2A09DDDD978A89BB524429D /* DataFrame+JoinIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E362A4F7A7B77E8B4041DE0 /* DataFrame+JoinIndex.swift */; };
+		C325F1563015EA291F3BA991 /* VectorSearchShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 60B4097CAF5406D46CADAA9F /* VectorSearchShaders.metal */; };
 		C57E56FD92C1606643EA4C64 /* MetalDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97BCB58448CB33E6D7B54224 /* MetalDispatch.swift */; };
 		CA3F4B533476FB376807C6EF /* khash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E209DB760F4CBFC327B5BBC /* khash.h */; };
 		CA7F12162580B04C132312BB /* ultrajsondec.c in Sources */ = {isa = PBXBuildFile; fileRef = 33D3A3C57157A8B084612879 /* ultrajsondec.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
@@ -127,10 +145,13 @@
 		CD90D4C6AFE9B359A901E7F8 /* SwiftPandas.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C289550B9C9C6036608C34E7 /* SwiftPandas.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFF0E3C0BFC711C9C3B18F9A /* MergeShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 4525D3C37734796C534282A9 /* MergeShaders.metal */; };
 		D17F565CF4D57438DB1CAD04 /* JSONReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F41279254571BC8F176FA86 /* JSONReader.swift */; };
+		D4A1FA993A40397F2DC96636 /* VectorSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598A8FF2F271D8A38F008042 /* VectorSearch.swift */; };
 		D7C70F105F0EC95A58A85B03 /* SwiftPandas.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28F3D18AE1E2EE81DE5CB83 /* SwiftPandas.swift */; };
 		DB2BED9171563AC0EA69338A /* ultrajson.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD5074D92B6D34F1D59DD03 /* ultrajson.h */; };
+		DC4146A2EA4F24BF91DBD6BE /* SPBFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D75BE7B06562B0BDBF8B081 /* SPBFormat.swift */; };
 		DC96C125C8B9CDD5D43AC0C3 /* LazyDataFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389B64E9FF0CA17AF9767C2C /* LazyDataFrame.swift */; };
 		DCF218B62711F3F855137597 /* ultrajson.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD5074D92B6D34F1D59DD03 /* ultrajson.h */; };
+		DF19896838BD20DC6DB21277 /* SPBFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D75BE7B06562B0BDBF8B081 /* SPBFormat.swift */; };
 		E2A1020ACF50A59DC654EB55 /* MetalMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F8BF25398E15233CBBFD30 /* MetalMerge.swift */; };
 		E2C938DC56B32B5E496CF200 /* CSVReaderStrict.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5B4894C65527BF4E2EB32B /* CSVReaderStrict.swift */; };
 		E88188C536FCA32684BB4D12 /* JSONTransformParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77873A3969C7EF9C55513707 /* JSONTransformParser.swift */; };
@@ -138,6 +159,8 @@
 		EACE7D3C5AB72581F28193E1 /* MetalShaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E84DEBD0790B057CABF32 /* MetalShaders.swift */; };
 		EC1C0D5DDFD7904F1B81B5B4 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2C94339382772F892E30D8 /* Client.swift */; };
 		EC6777C9B6466BA0BBC683BD /* GroupByDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77843E7925F9C6244F7E6C39 /* GroupByDemoView.swift */; };
+		EC70892202BDF7887066B6D7 /* MetalVectorSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7CED00B10DFCA6872D66AE /* MetalVectorSearchTests.swift */; };
+		ED50511EB495DAD0E2506DEF /* SPBReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C9139AC274906AC1406314 /* SPBReader.swift */; };
 		EEAA9A7327E58065497F9F5C /* GroupByShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 19D846DA71CE9577F41EE749 /* GroupByShaders.metal */; };
 		EFBCCF2E232570BE67D78F39 /* HotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB7B7363989C628E7DEB7D /* HotStore.swift */; };
 		F0A342F3697757C62A77D911 /* MetalDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97BCB58448CB33E6D7B54224 /* MetalDispatch.swift */; };
@@ -145,6 +168,7 @@
 		F4E22D3B590A4C43C20533D3 /* MetalMerge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F8BF25398E15233CBBFD30 /* MetalMerge.swift */; };
 		F811B63410C0786B85E41750 /* SwiftPandas.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C289550B9C9C6036608C34E7 /* SwiftPandas.framework */; };
 		F811F956FB159B326F88977B /* CSVMappedReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98B5FE0308E5AFCDF0EE98C /* CSVMappedReadTests.swift */; };
+		F84829F48908547502A4A95B /* SPBReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C9139AC274906AC1406314 /* SPBReader.swift */; };
 		F9402D2323F3FEE4877690A5 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7464B03A7DE52D165D759490 /* Buffer.swift */; };
 		F94EC083FD297FBABA51AB08 /* CSVReaderStrict.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5B4894C65527BF4E2EB32B /* CSVReaderStrict.swift */; };
 		FCB90F4E4E784844D1578B80 /* SwiftPandasCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AE9EBED26B06D39CBA9A43 /* SwiftPandasCLI.swift */; };
@@ -213,6 +237,8 @@
 		19D846DA71CE9577F41EE749 /* GroupByShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = GroupByShaders.metal; sourceTree = "<group>"; };
 		1B8817FEF468D972F755B00C /* SwiftPandasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftPandasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1C71DD80FE58C1F98A5AED83 /* SwiftPandasCLI */ = {isa = PBXFileReference; includeInIndex = 0; path = SwiftPandasCLI; sourceTree = BUILT_PRODUCTS_DIR; };
+		1D75BE7B06562B0BDBF8B081 /* SPBFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBFormat.swift; sourceTree = "<group>"; };
+		1F7CED00B10DFCA6872D66AE /* MetalVectorSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVectorSearchTests.swift; sourceTree = "<group>"; };
 		2181EEE84B163800594FA046 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
 		22AD38D7ECCD6EE5B8BF2F73 /* PandasArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PandasArray.swift; sourceTree = "<group>"; };
 		26C63CA072F41616045F85D2 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
@@ -236,7 +262,9 @@
 		4525D3C37734796C534282A9 /* MergeShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = MergeShaders.metal; sourceTree = "<group>"; };
 		46BC5D47091871B54416C613 /* Series.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Series.swift; sourceTree = "<group>"; };
 		51CE8C7146A7AE19A13AE2B4 /* NullableArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullableArray.swift; sourceTree = "<group>"; };
+		598A8FF2F271D8A38F008042 /* VectorSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorSearch.swift; sourceTree = "<group>"; };
 		5F41279254571BC8F176FA86 /* JSONReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONReader.swift; sourceTree = "<group>"; };
+		60B4097CAF5406D46CADAA9F /* VectorSearchShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = VectorSearchShaders.metal; sourceTree = "<group>"; };
 		67F8BF25398E15233CBBFD30 /* MetalMerge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalMerge.swift; sourceTree = "<group>"; };
 		69B4A80FBDBCF0C0B9E3FDDA /* QueryExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryExecutor.swift; sourceTree = "<group>"; };
 		6CD5074D92B6D34F1D59DD03 /* ultrajson.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ultrajson.h; sourceTree = "<group>"; };
@@ -249,17 +277,23 @@
 		755EA62922A9F0EB0A476736 /* skiplist.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = skiplist.h; sourceTree = "<group>"; };
 		77843E7925F9C6244F7E6C39 /* GroupByDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupByDemoView.swift; sourceTree = "<group>"; };
 		77873A3969C7EF9C55513707 /* JSONTransformParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTransformParser.swift; sourceTree = "<group>"; };
+		7E3B60D77C618C75E34E2B0D /* VectorArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorArray.swift; sourceTree = "<group>"; };
 		7F32C7C94134212AA97B6684 /* Daemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Daemon.swift; sourceTree = "<group>"; };
+		7F37FC6A89F3FF467732709E /* VectorSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorSearchTests.swift; sourceTree = "<group>"; };
 		8367516C42A9B6BF39B6670F /* CSVLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVLine.swift; sourceTree = "<group>"; };
+		850D9E672AE1D3BFA1E7E1F3 /* SPBWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBWriter.swift; sourceTree = "<group>"; };
 		8E3AE7F83FF3067EDC7E12DB /* ClientCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientCommands.swift; sourceTree = "<group>"; };
 		9152C67A4012AE1ED95C17D0 /* MetalGroupBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalGroupBy.swift; sourceTree = "<group>"; };
+		9260936CC73E2357A37194C2 /* BitVectorInvariantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitVectorInvariantTests.swift; sourceTree = "<group>"; };
 		956B46CC7F17CE58186D668F /* JoinIndexAndMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinIndexAndMemoryTests.swift; sourceTree = "<group>"; };
 		97BCB58448CB33E6D7B54224 /* MetalDispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalDispatch.swift; sourceTree = "<group>"; };
 		9957741BCE97B414826DCE85 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		9A99DFCEF5DDD4349827FEF3 /* employees.csv */ = {isa = PBXFileReference; path = employees.csv; sourceTree = "<group>"; };
 		9D2C94339382772F892E30D8 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		9D2FBF2E5C3601D28C2E1080 /* VectorOpsMatrixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorOpsMatrixTests.swift; sourceTree = "<group>"; };
 		9F877B1C6BBEB8C3A073AD2E /* portable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = portable.h; sourceTree = "<group>"; };
 		A28F3D18AE1E2EE81DE5CB83 /* SwiftPandas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPandas.swift; sourceTree = "<group>"; };
+		A44B9B2D3345EC176399F8F9 /* VectorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorError.swift; sourceTree = "<group>"; };
 		A57050F20F42C904FEFFA187 /* MetalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalTests.swift; sourceTree = "<group>"; };
 		A83B1B5C5B972FA793F9FCAF /* OtherDTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherDTypes.swift; sourceTree = "<group>"; };
 		A9B9154E503F8C0AF170E60A /* skiplist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = skiplist.c; sourceTree = "<group>"; };
@@ -267,7 +301,10 @@
 		B46E84DEBD0790B057CABF32 /* MetalShaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalShaders.swift; sourceTree = "<group>"; };
 		B54D6E77C32787D67DA7B197 /* HotStoreTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotStoreTypes.swift; sourceTree = "<group>"; };
 		B5DB7B7363989C628E7DEB7D /* HotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotStore.swift; sourceTree = "<group>"; };
+		B6C85A6772EEDDA425BF75C4 /* VectorSeriesOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorSeriesOps.swift; sourceTree = "<group>"; };
+		B6C9139AC274906AC1406314 /* SPBReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBReader.swift; sourceTree = "<group>"; };
 		B723F0FB414EF1DB0930CEF4 /* CLIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIError.swift; sourceTree = "<group>"; };
+		B9C238BF3F664ECAC011A4F2 /* MetalVectorSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVectorSearch.swift; sourceTree = "<group>"; };
 		BAF54ED5FF37B295D2EC94FE /* FrameCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameCache.swift; sourceTree = "<group>"; };
 		C24D37B50C94748102DA0EC9 /* DType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DType.swift; sourceTree = "<group>"; };
 		C24DACC00151A746CCD8F02C /* HotStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotStoreTests.swift; sourceTree = "<group>"; };
@@ -290,6 +327,8 @@
 		ED8D61E4DE52C89E91401CEE /* DataFrame+Memory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataFrame+Memory.swift"; sourceTree = "<group>"; };
 		EDD9E552B3EE0341E8D16FBD /* BitVector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitVector.swift; sourceTree = "<group>"; };
 		F144E9A25383F5A6574D65C3 /* employees.csv */ = {isa = PBXFileReference; path = employees.csv; sourceTree = "<group>"; };
+		F2DE67160B920ABE30D3E9AD /* VectorColumnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorColumnTests.swift; sourceTree = "<group>"; };
+		F8217FE89128CBAA23D3EE86 /* SPBTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPBTests.swift; sourceTree = "<group>"; };
 		F845FA91A1F9266A74A73600 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		F951783B44D4F86D221F5EB5 /* Predicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Predicate.swift; sourceTree = "<group>"; };
 		FCD61785C1C8586D7F55DFDC /* Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transport.swift; sourceTree = "<group>"; };
@@ -343,6 +382,7 @@
 				9152C67A4012AE1ED95C17D0 /* MetalGroupBy.swift */,
 				67F8BF25398E15233CBBFD30 /* MetalMerge.swift */,
 				B46E84DEBD0790B057CABF32 /* MetalShaders.swift */,
+				B9C238BF3F664ECAC011A4F2 /* MetalVectorSearch.swift */,
 			);
 			path = Metal;
 			sourceTree = "<group>";
@@ -379,6 +419,7 @@
 				19D846DA71CE9577F41EE749 /* GroupByShaders.metal */,
 				4525D3C37734796C534282A9 /* MergeShaders.metal */,
 				DCD547CE28268E228BA21D66 /* ShaderCommon.h */,
+				60B4097CAF5406D46CADAA9F /* VectorSearchShaders.metal */,
 			);
 			path = Shaders;
 			sourceTree = "<group>";
@@ -478,6 +519,7 @@
 				08367D3CD71EED91B9E7B6D1 /* Metal */,
 				2080D138C43B69B93607BF4A /* Numeric */,
 				D4137E24CCB495BFCFC9899F /* Series */,
+				D99941AA9DE65D49FDB49677 /* Vector */,
 				A28F3D18AE1E2EE81DE5CB83 /* SwiftPandas.swift */,
 			);
 			path = SwiftPandas;
@@ -499,6 +541,16 @@
 				2A79B4DE524F0E41BC29999A /* GUIApp.swift */,
 			);
 			path = GUI;
+			sourceTree = "<group>";
+		};
+		7830668E878FCD7429FA5F06 /* SPB */ = {
+			isa = PBXGroup;
+			children = (
+				1D75BE7B06562B0BDBF8B081 /* SPBFormat.swift */,
+				B6C9139AC274906AC1406314 /* SPBReader.swift */,
+				850D9E672AE1D3BFA1E7E1F3 /* SPBWriter.swift */,
+			);
+			path = SPB;
 			sourceTree = "<group>";
 		};
 		7D6D4EC3AE88C12B75AE257A /* DataFrame */ = {
@@ -578,6 +630,7 @@
 			children = (
 				8E3A36BDB8F68DC137BA46F1 /* SampleData */,
 				4460308C3F8C76BC0CF03DD7 /* BenchmarkTests.swift */,
+				9260936CC73E2357A37194C2 /* BitVectorInvariantTests.swift */,
 				0FCCB61BB16AEA54B22EC0D5 /* CSVContractTests.swift */,
 				C3EFE7CEE668B282BD8F794A /* CSVDataFrameTests.swift */,
 				E98B5FE0308E5AFCDF0EE98C /* CSVMappedReadTests.swift */,
@@ -586,8 +639,13 @@
 				956B46CC7F17CE58186D668F /* JoinIndexAndMemoryTests.swift */,
 				FE13536785EE5BFC02BD2E0D /* LazyDataFrameTests.swift */,
 				A57050F20F42C904FEFFA187 /* MetalTests.swift */,
+				1F7CED00B10DFCA6872D66AE /* MetalVectorSearchTests.swift */,
 				00B0C44E96FFC94F7C320429 /* NewFeaturesTests.swift */,
+				F8217FE89128CBAA23D3EE86 /* SPBTests.swift */,
 				D54E7E44184A38DD3BF2467A /* SwiftPandasTests.swift */,
+				F2DE67160B920ABE30D3E9AD /* VectorColumnTests.swift */,
+				9D2FBF2E5C3601D28C2E1080 /* VectorOpsMatrixTests.swift */,
+				7F37FC6A89F3FF467732709E /* VectorSearchTests.swift */,
 			);
 			path = SwiftPandasTests;
 			sourceTree = "<group>";
@@ -650,6 +708,17 @@
 			path = Series;
 			sourceTree = "<group>";
 		};
+		D99941AA9DE65D49FDB49677 /* Vector */ = {
+			isa = PBXGroup;
+			children = (
+				7E3B60D77C618C75E34E2B0D /* VectorArray.swift */,
+				A44B9B2D3345EC176399F8F9 /* VectorError.swift */,
+				598A8FF2F271D8A38F008042 /* VectorSearch.swift */,
+				B6C85A6772EEDDA425BF75C4 /* VectorSeriesOps.swift */,
+			);
+			path = Vector;
+			sourceTree = "<group>";
+		};
 		E2D4986F2EA16558E2244C91 /* include */ = {
 			isa = PBXGroup;
 			children = (
@@ -664,6 +733,7 @@
 			children = (
 				665A03AB81E3749244B4B9C9 /* CSV */,
 				27ADAABEB5280E8E9DFEC737 /* JSON */,
+				7830668E878FCD7429FA5F06 /* SPB */,
 			);
 			path = IO;
 			sourceTree = "<group>";
@@ -872,8 +942,8 @@
 				06FEE45C2F882A118ECED543 /* SwiftPandas */,
 				F52960BE5B08F2D4C89EAE80 /* SwiftPandas-iOS */,
 				DB7040382E19EEC0B53C647B /* SwiftPandasApp */,
-				BCB05BEBCBFC94FFC0B2EB5F /* SwiftPandasCLI */,
 				27684C8A15AFB445B6093339 /* SwiftPandasTests */,
+				BCB05BEBCBFC94FFC0B2EB5F /* SwiftPandasCLI */,
 			);
 		};
 /* End PBXProject section */
@@ -956,6 +1026,7 @@
 				176BE03DA4B4CB9677F56423 /* MetalGroupBy.swift in Sources */,
 				F4E22D3B590A4C43C20533D3 /* MetalMerge.swift in Sources */,
 				EACE7D3C5AB72581F28193E1 /* MetalShaders.swift in Sources */,
+				AFF6F64F0DB36E7B3B798F23 /* MetalVectorSearch.swift in Sources */,
 				7D1F90B44CC577AE38B28D02 /* NativeArray.swift in Sources */,
 				8CDDF12645D4E56252944F10 /* NullableArray.swift in Sources */,
 				015BD21E1127BEF42E215844 /* NumericDTypes.swift in Sources */,
@@ -965,11 +1036,19 @@
 				9859BF8EA017E88FEFBC3BAA /* QueryExecutor.swift in Sources */,
 				34F6A6EEE4F70A80DCDE9701 /* QueryOptimizer.swift in Sources */,
 				7708CE8FA8C9593365A8CC1C /* QueryPlan.swift in Sources */,
+				DF19896838BD20DC6DB21277 /* SPBFormat.swift in Sources */,
+				F84829F48908547502A4A95B /* SPBReader.swift in Sources */,
+				2AE6CDBCF06A41ED64D3292B /* SPBWriter.swift in Sources */,
 				6778382791474156F296E43A /* Series.swift in Sources */,
 				B90C8117C830AA8BF72D297E /* StringArray.swift in Sources */,
 				0E9A5CA21F70D399F8002F52 /* SwiftPandas.swift in Sources */,
 				31F375C6C110E468E0929A08 /* TextCache.swift in Sources */,
+				3585A5214089DFD0319B0C96 /* VectorArray.swift in Sources */,
+				26A4106B9570C4D57F5AE704 /* VectorError.swift in Sources */,
 				84F60AFAB78AC00365E40986 /* VectorOps.swift in Sources */,
+				D4A1FA993A40397F2DC96636 /* VectorSearch.swift in Sources */,
+				012BA7EE8B8853F571E0528B /* VectorSearchShaders.metal in Sources */,
+				AA3BE1D3BBFF86CDE1DF379B /* VectorSeriesOps.swift in Sources */,
 				2F83E1ABFEFA6F47DCF7836F /* khash.c in Sources */,
 				CC569576C2E3E4FB942AC1AB /* skiplist.c in Sources */,
 				CA7F12162580B04C132312BB /* ultrajsondec.c in Sources */,
@@ -982,6 +1061,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				837D57E390A3B5D9CA75CB7B /* BenchmarkTests.swift in Sources */,
+				795BAD065F6D88035B9B6A5A /* BitVectorInvariantTests.swift in Sources */,
 				9B20A6E12DF6D85A5FEEB244 /* CSVContractTests.swift in Sources */,
 				5DC583AF471388A23624240B /* CSVDataFrameTests.swift in Sources */,
 				F811F956FB159B326F88977B /* CSVMappedReadTests.swift in Sources */,
@@ -990,8 +1070,13 @@
 				AF9FF06D8095079569F31D24 /* JoinIndexAndMemoryTests.swift in Sources */,
 				1DE34837FAB9CAF41D7BB2C1 /* LazyDataFrameTests.swift in Sources */,
 				5B790ED8BAB7DEA8B371046F /* MetalTests.swift in Sources */,
+				EC70892202BDF7887066B6D7 /* MetalVectorSearchTests.swift in Sources */,
 				7B12FB5FA55C994067F68B82 /* NewFeaturesTests.swift in Sources */,
+				A066E7527EDCF15ED6946EC5 /* SPBTests.swift in Sources */,
 				499F95EA6EC3DD1BC773C09F /* SwiftPandasTests.swift in Sources */,
+				28B012B478C8CC2E465F0B7D /* VectorColumnTests.swift in Sources */,
+				328DB4501CCFF0C4401553C2 /* VectorOpsMatrixTests.swift in Sources */,
+				152A2C36E4E5230619CABBDD /* VectorSearchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1037,6 +1122,7 @@
 				8C6EDF782DC146BB2C0386E9 /* MetalGroupBy.swift in Sources */,
 				E2A1020ACF50A59DC654EB55 /* MetalMerge.swift in Sources */,
 				91DC5A926733A507A044224A /* MetalShaders.swift in Sources */,
+				2AB2299A8DFE96A0E703C273 /* MetalVectorSearch.swift in Sources */,
 				85DCE13E5A6EFD34D67D6D2E /* NativeArray.swift in Sources */,
 				7814EC209B984E84282B4F52 /* NullableArray.swift in Sources */,
 				9BB5855F4DE49AE9DC90664F /* NumericDTypes.swift in Sources */,
@@ -1046,11 +1132,19 @@
 				1E368632F138FB901490B22C /* QueryExecutor.swift in Sources */,
 				7C27A5E497B2C844A912DE6C /* QueryOptimizer.swift in Sources */,
 				9FB53F9EC567895D7126CABC /* QueryPlan.swift in Sources */,
+				DC4146A2EA4F24BF91DBD6BE /* SPBFormat.swift in Sources */,
+				ED50511EB495DAD0E2506DEF /* SPBReader.swift in Sources */,
+				020AE531981BEBC0DDBA000D /* SPBWriter.swift in Sources */,
 				B09AABE6C2E0B1E4B3E8CABC /* Series.swift in Sources */,
 				642648E72CFAE2C45842489D /* StringArray.swift in Sources */,
 				D7C70F105F0EC95A58A85B03 /* SwiftPandas.swift in Sources */,
 				B12C69A6B3B63776C3281563 /* TextCache.swift in Sources */,
+				3BE2BB39CD5D2B9C8DB20C03 /* VectorArray.swift in Sources */,
+				11A1664593AF23DFB1081FF6 /* VectorError.swift in Sources */,
 				0FD353BC50F11AFA45DB69D2 /* VectorOps.swift in Sources */,
+				A8E079E7465CE901D2880990 /* VectorSearch.swift in Sources */,
+				C325F1563015EA291F3BA991 /* VectorSearchShaders.metal in Sources */,
+				82A3E79B5FDE8AEDD4728A00 /* VectorSeriesOps.swift in Sources */,
 				0D7A0049DBF49C7FFC96CBA8 /* khash.c in Sources */,
 				38934C4ACB339F9B15DF5B66 /* skiplist.c in Sources */,
 				6893BD2302FDBAC647DA9DB2 /* ultrajsondec.c in Sources */,

--- a/Tests/SwiftPandasTests/SwiftPandasTests.swift
+++ b/Tests/SwiftPandasTests/SwiftPandasTests.swift
@@ -43,7 +43,7 @@ import XCTest
 /// Ensures the public `SwiftPandasInfo.version` string matches the expected release.
 final class SwiftPandasTests: XCTestCase {
     func testVersion() {
-        XCTAssertEqual(SwiftPandasInfo.version, "0.8.0-beta")
+        XCTAssertEqual(SwiftPandasInfo.version, "0.8.1-beta")
     }
 }
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -114,7 +114,7 @@ For projects without a Package manifest — a pure-Xcode app, a workspace, or so
 
 ```bash
 # Latest stable XCFramework as of writing:
-gh release download v0.8.0-beta \
+gh release download v0.8.1-beta \
   --repo kiraa-ai/kiraa-swift-pandas \
   --pattern 'SwiftPandas.xcframework.zip'
 unzip SwiftPandas.xcframework.zip
@@ -123,7 +123,7 @@ unzip SwiftPandas.xcframework.zip
 
 Or download from <https://github.com/kiraa-ai/kiraa-swift-pandas/releases> in the browser.
 
-> **Note**: v0.8.0-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
+> **Note**: v0.8.1-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
 
 Move the unzipped `SwiftPandas.xcframework` into your project — somewhere committed-or-not depending on your preference. A common layout:
 
@@ -205,15 +205,15 @@ Each library-binary release requires running `scripts/build-xcframework.sh`. The
 
 ```bash
 # 1. Make sure you're on the tag you want to publish.
-git checkout v0.8.0-beta
+git checkout v0.8.1-beta
 
 # 2. Build, upload to the matching GitHub release, and auto-update
 #    Package.swift's url+checksum constants in one shot.
-scripts/build-xcframework.sh --release-tag v0.8.0-beta --update-package-swift
+scripts/build-xcframework.sh --release-tag v0.8.1-beta --update-package-swift
 
 # 3. Commit and push the Package.swift bump.
 git add Package.swift
-git commit -m "v0.8.0-beta: refresh XCFramework binary"
+git commit -m "v0.8.1-beta: refresh XCFramework binary"
 git push origin main
 
 # 4. Verify binary mode resolves cleanly:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Format for each item:
 
 ---
 
-## Where we are today (v0.8.0-beta)
+## Where we are today (v0.8.1-beta)
 
 | Capability | Status |
 |---|---|

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -491,7 +491,7 @@ The repo ships **twelve** demo scripts under `examples/cli/`, each comparing one
 
 ```bash
 # If you didn't clone the repo, grab them:
-gh release download v0.8.0-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
+gh release download v0.8.1-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
 # Or just `git clone https://github.com/kiraa-ai/kiraa-swift-pandas.git`
 
 # Then:


### PR DESCRIPTION
Version bump for the v0.8.1-beta release (BitVector `allValid` fix, #18 — merged via #19/#21).

- `Package.swift` pinned to the v0.8.1-beta XCFramework asset, checksum `f80f450a8f2561f06c7a0bd16b93d3e42544c565f71824fbb0cdd8aeda81ae5f`
- `SwiftPandasInfo.version` → `0.8.1-beta` (+ test)
- README: v0.8.1-beta release notes, version header/pin; project-structure and testing sections refreshed to match the tree
- docs: EMBEDDING / ROADMAP / TUTORIAL version references
- `SwiftPandas.xcodeproj` regenerated from `project.yml` (was missing the Vector, SPB, and newer test sources)

Tag `v0.8.1-beta` points at this commit; the GitHub release carries `SwiftPandas.xcframework.zip` built from it (3 slices: macOS arm64+x86_64, iOS, iOS simulator).