### PR TITLE
CSVReader.strict: add readValidated(from:) (closes #23)

### DIFF
--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -348,18 +348,25 @@ public struct CSVContractError: Error, LocalizedError {
 
     public var errorDescription: String? {
         failures.map {
-            "\($0.column): \($0.failedCount) cells failed \($0.declaredType) "
+            "\($0.column): \($0.failedCount) \($0.failedCount == 1 ? "cell" : "cells") failed \($0.declaredType) "
             + "(first '\($0.firstFailedValue)' at row \($0.firstFailedRow))"
         }.joined(separator: "; ")
     }
 }
 
 extension CSVReader {
-    /// Parses CSV text under this reader's mode and throws if any cell failed
-    /// its declared dtype — the returned frame always honors the contract, so
-    /// a corrupt cell can never silently become NA.
+    /// Parses CSV text under this reader's ``ParseMode`` and throws instead of
+    /// returning a frame in which a corrupt cell has silently become NA.
+    ///
+    /// Under ``ParseMode/strict(_:)`` a cell in a column declared as a float,
+    /// integer, or bool dtype that does not parse as that dtype is a contract
+    /// failure. Columns declared with any other dtype are stored as strings and
+    /// cannot fail, so they are never reported. Under ``ParseMode/infer`` and
+    /// ``ParseMode/allStrings`` there is no contract to violate, so this call
+    /// never throws and returns the same frame as ``read(from:)``.
     /// - Parameter text: The CSV text to parse.
-    /// - Returns: The parsed frame, every declared column honouring its dtype.
+    /// - Returns: The parsed frame, with every float, integer, and bool
+    ///   contract column fully parsed.
     /// - Throws: `CSVContractError` carrying one `ColumnParseFailure` per
     ///   column that had at least one cell fail its declared dtype.
     public func readValidated(from text: String) throws -> DataFrame {

--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -339,19 +339,28 @@ extension CSVReader {
 /// A strict read failed its declared contract: at least one cell in a
 /// declared column did not parse as its dtype. Carries the per-column report
 /// so the message names every offender.
-public struct CSVContractError: Error, LocalizedError {
+public struct CSVContractError: Error, LocalizedError, CustomStringConvertible, Sendable {
+    /// One entry per column that had at least one cell fail its declared
+    /// dtype, in header order.
     public let failures: [ColumnParseFailure]
 
+    /// Creates an error from the per-column report of a strict read.
     public init(failures: [ColumnParseFailure]) {
         self.failures = failures
     }
 
-    public var errorDescription: String? {
+    /// Every failing column on one line: its name, how many cells failed,
+    /// the declared dtype, and the first offending cell with its row.
+    public var description: String {
         failures.map {
             "\($0.column): \($0.failedCount) \($0.failedCount == 1 ? "cell" : "cells") failed \($0.declaredType) "
             + "(first '\($0.firstFailedValue)' at row \($0.firstFailedRow))"
         }.joined(separator: "; ")
     }
+
+    /// The same text as ``description``, so `localizedDescription` names
+    /// every offender rather than a generic operation-failed message.
+    public var errorDescription: String? { description }
 }
 
 extension CSVReader {

--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -333,3 +333,29 @@ extension CSVReader {
         return reversedKept.reversed()
     }
 }
+
+// MARK: - Contract-throwing read
+
+/// A strict read failed its declared contract: at least one cell in a
+/// declared column did not parse as its dtype. Carries the per-column report
+/// so the message names every offender.
+public struct CSVContractError: Error, LocalizedError {
+    public let failures: [ColumnParseFailure]
+
+    public init(failures: [ColumnParseFailure]) {
+        self.failures = failures
+    }
+}
+
+extension CSVReader {
+    /// Parses CSV text under this reader's mode and throws if any cell failed
+    /// its declared dtype — the returned frame always honors the contract, so
+    /// a corrupt cell can never silently become NA.
+    /// - Parameter text: The CSV text to parse.
+    /// - Returns: The parsed frame, every declared column honouring its dtype.
+    /// - Throws: `CSVContractError` carrying one `ColumnParseFailure` per
+    ///   column that had at least one cell fail its declared dtype.
+    public func readValidated(from text: String) throws -> DataFrame {
+        throw CSVContractError(failures: [])
+    }
+}

--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -345,6 +345,13 @@ public struct CSVContractError: Error, LocalizedError {
     public init(failures: [ColumnParseFailure]) {
         self.failures = failures
     }
+
+    public var errorDescription: String? {
+        failures.map {
+            "\($0.column): \($0.failedCount) cells failed \($0.declaredType) "
+            + "(first '\($0.firstFailedValue)' at row \($0.firstFailedRow))"
+        }.joined(separator: "; ")
+    }
 }
 
 extension CSVReader {
@@ -356,6 +363,8 @@ extension CSVReader {
     /// - Throws: `CSVContractError` carrying one `ColumnParseFailure` per
     ///   column that had at least one cell fail its declared dtype.
     public func readValidated(from text: String) throws -> DataFrame {
-        throw CSVContractError(failures: [])
+        let (frame, failures) = readWithReport(from: text)
+        guard failures.isEmpty else { throw CSVContractError(failures: failures) }
+        return frame
     }
 }

--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -363,7 +363,7 @@ extension CSVReader {
     /// failure. Columns declared with any other dtype are stored as strings and
     /// cannot fail, so they are never reported. Under ``ParseMode/infer`` and
     /// ``ParseMode/allStrings`` there is no contract to violate, so this call
-    /// never throws and returns the same frame as ``read(from:)``.
+    /// never throws and returns the same frame as ``read(from:)-(String)``.
     /// - Parameter text: The CSV text to parse.
     /// - Returns: The parsed frame, with every float, integer, and bool
     ///   contract column fully parsed.

--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -113,20 +113,13 @@ extension CSVReader {
         }
     }
 
-    /// Parses CSV text under this reader's ``ParseMode`` and throws instead of
-    /// returning a frame in which a corrupt cell has silently become NA.
-    ///
-    /// Under ``ParseMode/strict(_:)`` a cell in a column declared as a float,
-    /// integer, or bool dtype that does not parse as that dtype is a contract
-    /// failure. Columns declared with any other dtype are stored as strings and
-    /// cannot fail, so they are never reported. Under ``ParseMode/infer`` and
-    /// ``ParseMode/allStrings`` there is no contract to violate, so this call
-    /// never throws and returns the same frame as ``read(from:)-(String)``.
+    /// ``readWithReport(from:)-(String)`` with the report enforced: a frame is
+    /// returned only when it is empty, so a corrupt cell can never pass as NA.
     /// - Parameter text: The CSV text to parse.
-    /// - Returns: The parsed frame, with every float, integer, and bool
-    ///   contract column fully parsed.
-    /// - Throws: `CSVContractError` carrying one `ColumnParseFailure` per
-    ///   column that had at least one cell fail its declared dtype.
+    /// - Returns: The parsed frame.
+    /// - Throws: `CSVContractError` when any float, integer, or bool contract
+    ///   column had a cell that failed to parse. Never throws under
+    ///   ``ParseMode/infer`` or ``ParseMode/allStrings``.
     public func readValidated(from text: String) throws -> DataFrame {
         let (frame, failures) = readWithReport(from: text)
         guard failures.isEmpty else { throw CSVContractError(failures: failures) }

--- a/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
+++ b/Sources/SwiftPandas/IO/CSV/CSVReaderStrict.swift
@@ -3,8 +3,9 @@
 // CSVReaderStrict.swift
 // SwiftPandas — CSV I/O
 //
-// Contract-driven (strict / all-strings) parsing for CSVReader, plus the
-// per-column parse-failure report. This is the upstreamed replacement for
+// Contract-driven (strict / all-strings) parsing for CSVReader, the
+// per-column parse-failure report, and the throwing read that refuses a
+// frame whose contract was violated. This is the upstreamed replacement for
 // engine-side "makeColumn" loaders: dtype decisions come from a declared
 // contract, never from inference, so all-digit identifier columns can never
 // silently numerify.
@@ -48,6 +49,33 @@ public struct ColumnParseFailure: Equatable, Sendable {
     }
 }
 
+/// A strict read failed its declared contract: at least one cell in a
+/// declared column did not parse as its dtype. Carries the per-column report
+/// so the message names every offender.
+public struct CSVContractError: Error, LocalizedError, CustomStringConvertible, Sendable {
+    /// One entry per column that had at least one cell fail its declared
+    /// dtype, in header order.
+    public let failures: [ColumnParseFailure]
+
+    /// Creates an error from the per-column report of a strict read.
+    public init(failures: [ColumnParseFailure]) {
+        self.failures = failures
+    }
+
+    /// Every failing column on one line: its name, how many cells failed,
+    /// the declared dtype, and the first offending cell with its row.
+    public var description: String {
+        failures.map {
+            "\($0.column): \($0.failedCount) \($0.failedCount == 1 ? "cell" : "cells") failed \($0.declaredType) "
+            + "(first '\($0.firstFailedValue)' at row \($0.firstFailedRow))"
+        }.joined(separator: "; ")
+    }
+
+    /// The same text as ``description``, so `localizedDescription` names
+    /// every offender rather than a generic operation-failed message.
+    public var errorDescription: String? { description }
+}
+
 extension CSVReader {
     // MARK: - Public entry points
 
@@ -83,6 +111,26 @@ extension CSVReader {
         return data.withUnsafeBytes { rawBuf in
             readTypedFromBytes(rawBuf.bindMemory(to: UInt8.self))
         }
+    }
+
+    /// Parses CSV text under this reader's ``ParseMode`` and throws instead of
+    /// returning a frame in which a corrupt cell has silently become NA.
+    ///
+    /// Under ``ParseMode/strict(_:)`` a cell in a column declared as a float,
+    /// integer, or bool dtype that does not parse as that dtype is a contract
+    /// failure. Columns declared with any other dtype are stored as strings and
+    /// cannot fail, so they are never reported. Under ``ParseMode/infer`` and
+    /// ``ParseMode/allStrings`` there is no contract to violate, so this call
+    /// never throws and returns the same frame as ``read(from:)-(String)``.
+    /// - Parameter text: The CSV text to parse.
+    /// - Returns: The parsed frame, with every float, integer, and bool
+    ///   contract column fully parsed.
+    /// - Throws: `CSVContractError` carrying one `ColumnParseFailure` per
+    ///   column that had at least one cell fail its declared dtype.
+    public func readValidated(from text: String) throws -> DataFrame {
+        let (frame, failures) = readWithReport(from: text)
+        guard failures.isEmpty else { throw CSVContractError(failures: failures) }
+        return frame
     }
 
     // MARK: - Typed column building
@@ -331,56 +379,5 @@ extension CSVReader {
             }
         }
         return reversedKept.reversed()
-    }
-}
-
-// MARK: - Contract-throwing read
-
-/// A strict read failed its declared contract: at least one cell in a
-/// declared column did not parse as its dtype. Carries the per-column report
-/// so the message names every offender.
-public struct CSVContractError: Error, LocalizedError, CustomStringConvertible, Sendable {
-    /// One entry per column that had at least one cell fail its declared
-    /// dtype, in header order.
-    public let failures: [ColumnParseFailure]
-
-    /// Creates an error from the per-column report of a strict read.
-    public init(failures: [ColumnParseFailure]) {
-        self.failures = failures
-    }
-
-    /// Every failing column on one line: its name, how many cells failed,
-    /// the declared dtype, and the first offending cell with its row.
-    public var description: String {
-        failures.map {
-            "\($0.column): \($0.failedCount) \($0.failedCount == 1 ? "cell" : "cells") failed \($0.declaredType) "
-            + "(first '\($0.firstFailedValue)' at row \($0.firstFailedRow))"
-        }.joined(separator: "; ")
-    }
-
-    /// The same text as ``description``, so `localizedDescription` names
-    /// every offender rather than a generic operation-failed message.
-    public var errorDescription: String? { description }
-}
-
-extension CSVReader {
-    /// Parses CSV text under this reader's ``ParseMode`` and throws instead of
-    /// returning a frame in which a corrupt cell has silently become NA.
-    ///
-    /// Under ``ParseMode/strict(_:)`` a cell in a column declared as a float,
-    /// integer, or bool dtype that does not parse as that dtype is a contract
-    /// failure. Columns declared with any other dtype are stored as strings and
-    /// cannot fail, so they are never reported. Under ``ParseMode/infer`` and
-    /// ``ParseMode/allStrings`` there is no contract to violate, so this call
-    /// never throws and returns the same frame as ``read(from:)-(String)``.
-    /// - Parameter text: The CSV text to parse.
-    /// - Returns: The parsed frame, with every float, integer, and bool
-    ///   contract column fully parsed.
-    /// - Throws: `CSVContractError` carrying one `ColumnParseFailure` per
-    ///   column that had at least one cell fail its declared dtype.
-    public func readValidated(from text: String) throws -> DataFrame {
-        let (frame, failures) = readWithReport(from: text)
-        guard failures.isEmpty else { throw CSVContractError(failures: failures) }
-        return frame
     }
 }

--- a/Tests/SwiftPandasTests/CSVReaderValidatedTests.swift
+++ b/Tests/SwiftPandasTests/CSVReaderValidatedTests.swift
@@ -69,4 +69,19 @@ final class CSVReaderValidatedTests: XCTestCase {
             }
         }
     }
+
+    /// With no contract there is nothing to violate, so a cell that would
+    /// fail a float contract must still come back as a frame, never an error.
+    func test_readValidated_withoutContract_returnsFrameForUnparsableCell() throws {
+        // Given: an inferring reader and a cell no numeric dtype could parse
+        let reader = CSVReader()
+        let csvWithUnparsableCell = "id,value\nA001,1.5x\n"
+
+        // When: the text is read with no contract
+        let frame = try reader.readValidated(from: csvWithUnparsableCell)
+
+        // Then: the row is present; nothing was reported as a failure
+        XCTAssertEqual(frame.rowCount, 1,
+                       "readValidated — case 'no contract': want 1 row, got \(frame.rowCount)")
+    }
 }

--- a/Tests/SwiftPandasTests/CSVReaderValidatedTests.swift
+++ b/Tests/SwiftPandasTests/CSVReaderValidatedTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import SwiftPandas
+
+// ===----------------------------------------------------------------------===//
+// Tests for CSVReader.readValidated(from:): the strict read that owns its own
+// contract. It returns a frame only when every declared cell parsed, and
+// otherwise throws CSVContractError carrying the per-column report.
+// ===----------------------------------------------------------------------===//
+
+final class CSVReaderValidatedTests: XCTestCase {
+
+    /// A blank cell in a declared column is NA by contract, so it must never
+    /// be reported as a failure and the read must return the frame.
+    func test_readValidated_withBlankDeclaredCell_returnsFrameWithAllRows() throws {
+        // Given: a float64 contract on `value` and one blank `value` cell
+        let reader = CSVReader.strict(columnTypes: ["value": .float64])
+        let csvWithBlankCell = "id,value\nA001,1.5\nA002,\n"
+
+        // When: the text is read under the contract
+        let frame = try reader.readValidated(from: csvWithBlankCell)
+
+        // Then: both rows are present; the blank cell did not fail the contract
+        XCTAssertEqual(frame.rowCount, 2,
+                       "readValidated — case 'blank declared cell': want 2 rows, got \(frame.rowCount)")
+    }
+
+    /// A declared cell that fails its dtype parse must throw, and the error
+    /// must identify the column and the first offending cell.
+    func test_readValidated_withCorruptDeclaredCell_throwsContractErrorNamingTheCell() {
+        // Given: a float64 contract on `value` and one unparsable `value` cell
+        let reader = CSVReader.strict(columnTypes: ["value": .float64])
+        let csvWithCorruptCell = "id,value\nA001,1.5\nA002,1.5x\n"
+
+        // When: the text is read under the contract
+        // Then: the read throws CSVContractError naming `value` / `1.5x`
+        XCTAssertThrowsError(try reader.readValidated(from: csvWithCorruptCell),
+                             "readValidated — case 'corrupt declared cell': want CSVContractError, got a frame") { thrownError in
+            guard let contractError = thrownError as? CSVContractError else {
+                return XCTFail("readValidated — case 'corrupt declared cell': want CSVContractError, got \(thrownError)")
+            }
+            guard contractError.failures.count == 1, let failure = contractError.failures.first else {
+                return XCTFail("readValidated — case 'corrupt declared cell': want 1 failing column, got \(contractError.failures)")
+            }
+            XCTAssertEqual(failure.column, "value",
+                           "readValidated — case 'corrupt declared cell': want column 'value', got '\(failure.column)'")
+            XCTAssertEqual(failure.firstFailedValue, "1.5x",
+                           "readValidated — case 'corrupt declared cell': want first failed cell '1.5x', got '\(failure.firstFailedValue)'")
+        }
+    }
+
+    /// The error's message must name every failing column and its first
+    /// offending cell, so a logged error is enough to locate all the damage.
+    func test_readValidated_withTwoCorruptColumns_errorDescriptionNamesBoth() {
+        // Given: two declared columns, each with one unparsable cell
+        let reader = CSVReader.strict(columnTypes: ["lat": .float64, "count": .int64])
+        let csvWithTwoCorruptColumns = "id,lat,count\nA001,abc,7\nA002,1.5,seven\n"
+
+        // When: the text is read under the contract
+        // Then: the message names both columns and both offending cells
+        XCTAssertThrowsError(try reader.readValidated(from: csvWithTwoCorruptColumns),
+                             "readValidated — case 'two corrupt columns': want CSVContractError, got a frame") { thrownError in
+            guard let contractError = thrownError as? CSVContractError else {
+                return XCTFail("readValidated — case 'two corrupt columns': want CSVContractError, got \(thrownError)")
+            }
+            let message = contractError.errorDescription ?? ""
+            for expectedFragment in ["lat", "abc", "count", "seven"] {
+                XCTAssertTrue(message.contains(expectedFragment),
+                              "readValidated — case 'two corrupt columns': want message to mention '\(expectedFragment)', got '\(message)'")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `CSVReader.readValidated(from:)` — a throwing sibling of `readWithReport(from:)` that returns the frame only when every declared cell parsed, otherwise throws `CSVContractError` carrying the per-column `[ColumnParseFailure]` report. `errorDescription` renders every failing column.

Additive only: `readWithReport` is unchanged in signature, report, and frame bytes. Under `.infer` and `.allStrings` the report is always empty, so `readValidated` never throws there. Only float, integer, and bool contract columns can fail; other declared dtypes are stored as strings by the strict reader and are never reported (documented on the method).

Tests: `Tests/SwiftPandasTests/CSVReaderValidatedTests.swift` — clean text returns the frame (blank cells are NA, not failures); a corrupt declared cell throws naming column and cell; the error message names every failing column.

Not in this PR: `readValidated(from: URL)`, the file-path sibling — additive follow-up.

Pre-existing on `main` and unrelated: `MetalMergeTests.testInnerJoinCorrectness` / `testInnerJoinDuplicateKeys` fail identically on `6407f85`.

Closes #23
