### PR TITLE
release: v0.8.2-beta

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,8 +55,8 @@ let useBinary = ProcessInfo.processInfo.environment["SWIFTPANDAS_USE_BINARY"] ==
 // every tagged release: scripts/build-xcframework.sh prints the new
 // checksum after building, and the asset must be uploaded to the matching
 // GitHub release before consumers can resolve the binary target.
-let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.1-beta/SwiftPandas.xcframework.zip"
-let xcframeworkChecksum = "f80f450a8f2561f06c7a0bd16b93d3e42544c565f71824fbb0cdd8aeda81ae5f"
+let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.2-beta/SwiftPandas.xcframework.zip"
+let xcframeworkChecksum = "c2630fefad4f4fd224605c98542743e78bf11cf83404152f508fb12beb761129"
 
 // ── Source-mode targets ──
 let sourceTargets: [Target] = [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="swift_pandas.png" alt="SwiftPandas" width="400">
 </p>
 
-# SwiftPandas v0.8.1-beta
+# SwiftPandas v0.8.2-beta
 
 > **BETA RELEASE** — This library is under active development and testing. APIs may change between releases. We welcome bug reports and feedback via [GitHub Issues](https://github.com/kiraa-ai/kiraa-swift-pandas/issues).
 
@@ -13,6 +13,11 @@ SwiftPandas provides `DataFrame`, `Series`, and `Index` types for tabular data m
 The `swiftpandas` CLI ships a **resident-memory daemon mode** (`swiftpandas server start`) that lets multiple shell invocations share an in-memory `DataFrameRegistry`, so a load-once → many-pipes workflow is sub-15 ms per transform vs Python pandas's ~650 ms per-invocation cold-start tax. See [docs/SERVER.md](docs/SERVER.md) and the [examples/cli/](examples/cli/) directory for the full surface.
 
 **Want to try it for yourself?** [docs/TUTORIAL.md](docs/TUTORIAL.md) walks you through a complete analytics workflow twice — first in Python with pandas, then in `swiftpandas` running as a Homebrew-installed daemon. Same dataset, same operations, side-by-side timings. ~20 minutes start to finish.
+
+## What's new in v0.8.2-beta
+
+- **`CSVReader.readValidated(from:)`** — a throwing sibling of `readWithReport(from:)`. Returns the frame only when every declared float, integer, or bool contract column parsed; otherwise throws `CSVContractError` carrying one `ColumnParseFailure` per offending column, with `description` naming each column, its failure count, and the first bad cell. Under `.infer` and `.allStrings` it never throws. `readWithReport` is unchanged. Closes #23.
+- `CSVContractError` is `Sendable` and `CustomStringConvertible`, so `"\(error)"` prints the report rather than a struct dump.
 
 ## What's new in v0.8.1-beta
 
@@ -221,7 +226,7 @@ SwiftPandas supports two SwiftPM consumption modes from a single `Package.swift`
 
 ### Option A — Source build (default)
 
-Add SwiftPandas to your `Package.swift` and pin to the v0.8.1-beta tag (or track `main` for development):
+Add SwiftPandas to your `Package.swift` and pin to the v0.8.2-beta tag (or track `main` for development):
 
 ```swift
 // swift-tools-version: 5.9
@@ -232,7 +237,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     dependencies: [
         // Recommended: pin to a tagged release
-        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.1-beta"),
+        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.2-beta"),
 
         // Or track the latest development:
         // .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", branch: "main"),

--- a/Sources/SwiftPandas/SwiftPandas.swift
+++ b/Sources/SwiftPandas/SwiftPandas.swift
@@ -49,5 +49,5 @@ public enum SwiftPandasInfo {
     /// interface, so clients inline the literal and never need the symbol —
     /// the failure mode is impossible by construction, in any build mode.
     @inlinable
-    public static var version: String { "0.8.1-beta" }
+    public static var version: String { "0.8.2-beta" }
 }

--- a/SwiftPandas.xcodeproj/project.pbxproj
+++ b/SwiftPandas.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		AFF6F64F0DB36E7B3B798F23 /* MetalVectorSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C238BF3F664ECAC011A4F2 /* MetalVectorSearch.swift */; };
 		B09AABE6C2E0B1E4B3E8CABC /* Series.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BC5D47091871B54416C613 /* Series.swift */; };
 		B12C69A6B3B63776C3281563 /* TextCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD462251C90FFD82BE04714D /* TextCache.swift */; };
+		B2B26A07158C87601F917F48 /* CSVReaderValidatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55CB6EC41DA8E7F97B01E90 /* CSVReaderValidatedTests.swift */; };
 		B433902F318B689A03D2288E /* ultrajsonenc.c in Sources */ = {isa = PBXBuildFile; fileRef = E744C27B54AFC8DCB62CA803 /* ultrajsonenc.c */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		B8AFC714F378CE0A8C73CC78 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F951783B44D4F86D221F5EB5 /* Predicate.swift */; };
 		B90C8117C830AA8BF72D297E /* StringArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43E4688A860B3EA57425A30 /* StringArray.swift */; };
@@ -294,6 +295,7 @@
 		9F877B1C6BBEB8C3A073AD2E /* portable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = portable.h; sourceTree = "<group>"; };
 		A28F3D18AE1E2EE81DE5CB83 /* SwiftPandas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPandas.swift; sourceTree = "<group>"; };
 		A44B9B2D3345EC176399F8F9 /* VectorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorError.swift; sourceTree = "<group>"; };
+		A55CB6EC41DA8E7F97B01E90 /* CSVReaderValidatedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVReaderValidatedTests.swift; sourceTree = "<group>"; };
 		A57050F20F42C904FEFFA187 /* MetalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalTests.swift; sourceTree = "<group>"; };
 		A83B1B5C5B972FA793F9FCAF /* OtherDTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherDTypes.swift; sourceTree = "<group>"; };
 		A9B9154E503F8C0AF170E60A /* skiplist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = skiplist.c; sourceTree = "<group>"; };
@@ -634,6 +636,7 @@
 				0FCCB61BB16AEA54B22EC0D5 /* CSVContractTests.swift */,
 				C3EFE7CEE668B282BD8F794A /* CSVDataFrameTests.swift */,
 				E98B5FE0308E5AFCDF0EE98C /* CSVMappedReadTests.swift */,
+				A55CB6EC41DA8E7F97B01E90 /* CSVReaderValidatedTests.swift */,
 				6CFE849A42B05EAE9DA9B79F /* DataFrameMemoryTests.swift */,
 				C24DACC00151A746CCD8F02C /* HotStoreTests.swift */,
 				956B46CC7F17CE58186D668F /* JoinIndexAndMemoryTests.swift */,
@@ -1065,6 +1068,7 @@
 				9B20A6E12DF6D85A5FEEB244 /* CSVContractTests.swift in Sources */,
 				5DC583AF471388A23624240B /* CSVDataFrameTests.swift in Sources */,
 				F811F956FB159B326F88977B /* CSVMappedReadTests.swift in Sources */,
+				B2B26A07158C87601F917F48 /* CSVReaderValidatedTests.swift in Sources */,
 				BF5C02E03467964E891D2873 /* DataFrameMemoryTests.swift in Sources */,
 				967BE7B36BB99F2441DE4234 /* HotStoreTests.swift in Sources */,
 				AF9FF06D8095079569F31D24 /* JoinIndexAndMemoryTests.swift in Sources */,

--- a/Tests/SwiftPandasTests/SwiftPandasTests.swift
+++ b/Tests/SwiftPandasTests/SwiftPandasTests.swift
@@ -43,7 +43,7 @@ import XCTest
 /// Ensures the public `SwiftPandasInfo.version` string matches the expected release.
 final class SwiftPandasTests: XCTestCase {
     func testVersion() {
-        XCTAssertEqual(SwiftPandasInfo.version, "0.8.1-beta")
+        XCTAssertEqual(SwiftPandasInfo.version, "0.8.2-beta")
     }
 }
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -114,7 +114,7 @@ For projects without a Package manifest — a pure-Xcode app, a workspace, or so
 
 ```bash
 # Latest stable XCFramework as of writing:
-gh release download v0.8.1-beta \
+gh release download v0.8.2-beta \
   --repo kiraa-ai/kiraa-swift-pandas \
   --pattern 'SwiftPandas.xcframework.zip'
 unzip SwiftPandas.xcframework.zip
@@ -123,7 +123,7 @@ unzip SwiftPandas.xcframework.zip
 
 Or download from <https://github.com/kiraa-ai/kiraa-swift-pandas/releases> in the browser.
 
-> **Note**: v0.8.1-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
+> **Note**: v0.8.2-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
 
 Move the unzipped `SwiftPandas.xcframework` into your project — somewhere committed-or-not depending on your preference. A common layout:
 
@@ -205,15 +205,15 @@ Each library-binary release requires running `scripts/build-xcframework.sh`. The
 
 ```bash
 # 1. Make sure you're on the tag you want to publish.
-git checkout v0.8.1-beta
+git checkout v0.8.2-beta
 
 # 2. Build, upload to the matching GitHub release, and auto-update
 #    Package.swift's url+checksum constants in one shot.
-scripts/build-xcframework.sh --release-tag v0.8.1-beta --update-package-swift
+scripts/build-xcframework.sh --release-tag v0.8.2-beta --update-package-swift
 
 # 3. Commit and push the Package.swift bump.
 git add Package.swift
-git commit -m "v0.8.1-beta: refresh XCFramework binary"
+git commit -m "v0.8.2-beta: refresh XCFramework binary"
 git push origin main
 
 # 4. Verify binary mode resolves cleanly:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Format for each item:
 
 ---
 
-## Where we are today (v0.8.1-beta)
+## Where we are today (v0.8.2-beta)
 
 | Capability | Status |
 |---|---|

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -491,7 +491,7 @@ The repo ships **twelve** demo scripts under `examples/cli/`, each comparing one
 
 ```bash
 # If you didn't clone the repo, grab them:
-gh release download v0.8.1-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
+gh release download v0.8.2-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
 # Or just `git clone https://github.com/kiraa-ai/kiraa-swift-pandas.git`
 
 # Then:


### PR DESCRIPTION
Release commit for v0.8.2-beta, already tagged (`v0.8.2-beta` → `67ef669`) and published with `SwiftPandas.xcframework.zip` attached.

Bumps `SwiftPandasInfo.version`, the version test, README/ROADMAP/TUTORIAL/EMBEDDING references, and pins Package.swift to the v0.8.2-beta asset (checksum `c2630fefad4f4fd224605c98542743e78bf11cf83404152f508fb12beb761129`). Xcode project regenerated from project.yml.

**Merge with a merge commit (not squash/rebase)** so the tagged commit becomes an ancestor of `main`; a squash would leave the tag pointing at a commit outside `main`.
