### PR TITLE
Design: merge_hash_build duplicate-key race (#27) — candidate designs for review

### DIFF
--- a/Sources/SwiftPandas/Metal/MetalShaders.swift
+++ b/Sources/SwiftPandas/Metal/MetalShaders.swift
@@ -117,14 +117,14 @@
 //   **duplicate keys** in the right table (many-to-many joins). This is
 //   accomplished using a separate `chain_next` linked list array:
 //
-//   1. Hash the code and probe for the correct slot via linear probing.
-//   2. If the slot is empty (CAS succeeds), store the row index directly.
-//   3. If the slot already contains the same key (duplicate), use
-//      `atomic_exchange` to atomically swap in the new row index while
-//      retrieving the previous head of the chain. The previous head is then
-//      stored in `chain_next[tid]`, forming a singly-linked list of all
-//      right-table rows with the same key. The chain is effectively built
-//      in LIFO (stack) order.
+//   1. Hash the code and probe for the owning slot via linear probing,
+//      claiming the slot's key with a CAS when the slot is empty.
+//   2. Once the slot owns the key, every inserting thread — including the
+//      one that just claimed it — pushes its row onto the slot's chain the
+//      same way: `atomic_exchange` swaps the new row index into the slot
+//      while retrieving the previous head (-1 for an empty chain), which is
+//      then stored in `chain_next[tid]`. This forms a LIFO singly-linked
+//      list of all right-table rows sharing the same key.
 //
 // Merge Phase 2 — Hash Probe:
 //
@@ -449,11 +449,15 @@ internal enum MetalShaders {
     //         chain_next[N]  — linked list: chain_next[i] = previous row with
     //                          same key, or -1 if this is the oldest entry
     //
-    // The hash table stores one slot per unique key. When a duplicate key is
-    // inserted, the new row atomically replaces the slot's row_index (via
-    // atomic_exchange), and the previous row_index is saved in chain_next.
-    // This builds a LIFO singly-linked list of all right-table rows sharing
-    // the same key, enabling many-to-many join semantics in Phase 2.
+    // The hash table stores one slot per unique key. Every insert pushes its
+    // row onto the slot's chain: atomic_exchange swaps the new row_index in
+    // while returning the previous head (-1 for an empty chain), which is
+    // saved in chain_next. This builds a LIFO singly-linked list of all
+    // right-table rows sharing the same key, enabling many-to-many join
+    // semantics in Phase 2. Chains are complete only when this kernel's
+    // dispatch finishes; the probe runs in a separate command buffer after
+    // that (MetalContext.dispatch waits per dispatch), which is what makes
+    // relaxed atomic ordering sufficient throughout.
     // -----------------------------------------------------------------------
 
     struct MergeHashEntry {
@@ -482,23 +486,21 @@ internal enum MetalShaders {
         uint slot = hash_int32(code) & mask;
 
         while (true) {
-            // Try to claim an empty slot via CAS
+            // Claim the slot's key if empty. On failure `expected` holds the key
+            // currently in the slot; a weak CAS may also fail spuriously, leaving
+            // `expected` == EMPTY_SLOT — retry the same slot in that case so one
+            // key can never occupy two slots.
             int expected = EMPTY_SLOT;
-            if (atomic_compare_exchange_weak_explicit(
+            bool claimed = atomic_compare_exchange_weak_explicit(
                     &hash_table[slot].key, &expected, code,
-                    memory_order_relaxed, memory_order_relaxed)) {
-                // First row with this key in this slot — store directly
-                atomic_store_explicit(
-                    &hash_table[slot].row_index, (int)tid,
-                    memory_order_relaxed);
-                return;
-            }
-            int current = atomic_load_explicit(
-                &hash_table[slot].key, memory_order_relaxed);
-            if (current == code) {
-                // Duplicate key — prepend to the chain. atomic_exchange
-                // atomically swaps in our row index and returns the previous
-                // head, which we link via chain_next to form a LIFO list.
+                    memory_order_relaxed, memory_order_relaxed);
+            if (claimed || expected == code) {
+                // The slot owns this key. Every inserting thread pushes its row
+                // the same way: swap it in as the chain head and link the previous
+                // head (or the -1 empty-chain sentinel) behind it. Chains are
+                // complete only once the kernel finishes; relaxed ordering
+                // suffices because the probe runs in a later command buffer,
+                // after this dispatch completes.
                 int old_head = atomic_exchange_explicit(
                     &hash_table[slot].row_index, (int)tid,
                     memory_order_relaxed);
@@ -507,8 +509,10 @@ internal enum MetalShaders {
                     memory_order_relaxed);
                 return;
             }
-            // Hash collision (different key) — linear probe
-            slot = (slot + 1) & mask;
+            if (expected != EMPTY_SLOT) {
+                // Occupied by a different key — linear-probe onward.
+                slot = (slot + 1) & mask;
+            }
         }
     }
 

--- a/Sources/SwiftPandas/Metal/MetalShaders.swift
+++ b/Sources/SwiftPandas/Metal/MetalShaders.swift
@@ -453,10 +453,12 @@ internal enum MetalShaders {
     // row onto the slot's chain: atomic_exchange swaps the new row_index in
     // while returning the previous head (-1 for an empty chain), which is
     // saved in chain_next. This builds a LIFO singly-linked list of all
-    // right-table rows sharing the same key, enabling many-to-many join
-    // semantics in Phase 2. Chains are complete only when this kernel's
-    // dispatch finishes; the probe runs in a separate command buffer after
-    // that (MetalContext.dispatch waits per dispatch), which is what makes
+    // right-table rows sharing the same key. The probe kernel
+    // (merge_hash_probe, defined below) later walks each list to emit one
+    // join match per row — this is how one key matching many rows is
+    // supported. Chains are complete only when this kernel's dispatch
+    // finishes; the probe runs in a separate command buffer after that
+    // (MetalContext.dispatch waits per dispatch), which is what makes
     // relaxed atomic ordering sufficient throughout.
     // -----------------------------------------------------------------------
 
@@ -485,22 +487,26 @@ internal enum MetalShaders {
         uint mask = params.capacity - 1;
         uint slot = hash_int32(code) & mask;
 
+        // Insert this row into the slot owned by its key. Each pass through
+        // the loop ends one of three ways:
+        //   - the slot holds this row's key (just claimed, or already there):
+        //     push the row onto the slot's chain and return
+        //   - the slot holds a different key: linear-probe to the next slot
+        //   - the CAS failed spuriously: retry the same slot
         while (true) {
-            // Claim the slot's key if empty. On failure `expected` holds the key
-            // currently in the slot; a weak CAS may also fail spuriously, leaving
-            // `expected` == EMPTY_SLOT — retry the same slot in that case so one
-            // key can never occupy two slots.
             int expected = EMPTY_SLOT;
             bool claimed = atomic_compare_exchange_weak_explicit(
                     &hash_table[slot].key, &expected, code,
                     memory_order_relaxed, memory_order_relaxed);
+            // On CAS failure, `expected` holds the key currently in the slot.
             if (claimed || expected == code) {
-                // The slot owns this key. Every inserting thread pushes its row
-                // the same way: swap it in as the chain head and link the previous
-                // head (or the -1 empty-chain sentinel) behind it. Chains are
-                // complete only once the kernel finishes; relaxed ordering
-                // suffices because the probe runs in a later command buffer,
-                // after this dispatch completes.
+                // Push: swap this row in as the new chain head, then link the
+                // previous head behind it. An empty chain needs no special
+                // handling — its head is -1, which is also the end-of-chain
+                // marker every row links to eventually.
+                // Relaxed ordering is sufficient: chains are only read by the
+                // probe kernel, which runs in a later command buffer, after
+                // this dispatch has fully completed.
                 int old_head = atomic_exchange_explicit(
                     &hash_table[slot].row_index, (int)tid,
                     memory_order_relaxed);
@@ -510,9 +516,12 @@ internal enum MetalShaders {
                 return;
             }
             if (expected != EMPTY_SLOT) {
-                // Occupied by a different key — linear-probe onward.
+                // A different key owns this slot — probe onward.
                 slot = (slot + 1) & mask;
             }
+            // Otherwise the weak CAS failed spuriously even though the slot is
+            // empty (permitted by MSL) — loop again on this same slot, so one
+            // key can never end up split across two slots.
         }
     }
 

--- a/Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal
+++ b/Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal
@@ -29,22 +29,26 @@ kernel void merge_hash_build(
     uint mask = params.capacity - 1;
     uint slot = hash_int32(code) & mask;
 
+    // Insert this row into the slot owned by its key. Each pass through
+    // the loop ends one of three ways:
+    //   - the slot holds this row's key (just claimed, or already there):
+    //     push the row onto the slot's chain and return
+    //   - the slot holds a different key: linear-probe to the next slot
+    //   - the CAS failed spuriously: retry the same slot
     while (true) {
-        // Claim the slot's key if empty. On failure `expected` holds the key
-        // currently in the slot; a weak CAS may also fail spuriously, leaving
-        // `expected` == EMPTY_SLOT — retry the same slot in that case so one
-        // key can never occupy two slots.
         int expected = EMPTY_SLOT;
         bool claimed = atomic_compare_exchange_weak_explicit(
                 &hash_table[slot].key, &expected, code,
                 memory_order_relaxed, memory_order_relaxed);
+        // On CAS failure, `expected` holds the key currently in the slot.
         if (claimed || expected == code) {
-            // The slot owns this key. Every inserting thread pushes its row
-            // the same way: swap it in as the chain head and link the previous
-            // head (or the -1 empty-chain sentinel) behind it. Chains are
-            // complete only once the kernel finishes; relaxed ordering
-            // suffices because the probe runs in a later command buffer,
-            // after this dispatch completes.
+            // Push: swap this row in as the new chain head, then link the
+            // previous head behind it. An empty chain needs no special
+            // handling — its head is -1, which is also the end-of-chain
+            // marker every row links to eventually.
+            // Relaxed ordering is sufficient: chains are only read by the
+            // probe kernel, which runs in a later command buffer, after
+            // this dispatch has fully completed.
             int old_head = atomic_exchange_explicit(
                 &hash_table[slot].row_index, (int)tid,
                 memory_order_relaxed);
@@ -54,9 +58,12 @@ kernel void merge_hash_build(
             return;
         }
         if (expected != EMPTY_SLOT) {
-            // Occupied by a different key — linear-probe onward.
+            // A different key owns this slot — probe onward.
             slot = (slot + 1) & mask;
         }
+        // Otherwise the weak CAS failed spuriously even though the slot is
+        // empty (permitted by MSL) — loop again on this same slot, so one
+        // key can never end up split across two slots.
     }
 }
 

--- a/Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal
+++ b/Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal
@@ -30,18 +30,21 @@ kernel void merge_hash_build(
     uint slot = hash_int32(code) & mask;
 
     while (true) {
+        // Claim the slot's key if empty. On failure `expected` holds the key
+        // currently in the slot; a weak CAS may also fail spuriously, leaving
+        // `expected` == EMPTY_SLOT — retry the same slot in that case so one
+        // key can never occupy two slots.
         int expected = EMPTY_SLOT;
-        if (atomic_compare_exchange_weak_explicit(
+        bool claimed = atomic_compare_exchange_weak_explicit(
                 &hash_table[slot].key, &expected, code,
-                memory_order_relaxed, memory_order_relaxed)) {
-            atomic_store_explicit(
-                &hash_table[slot].row_index, (int)tid,
-                memory_order_relaxed);
-            return;
-        }
-        int current = atomic_load_explicit(
-            &hash_table[slot].key, memory_order_relaxed);
-        if (current == code) {
+                memory_order_relaxed, memory_order_relaxed);
+        if (claimed || expected == code) {
+            // The slot owns this key. Every inserting thread pushes its row
+            // the same way: swap it in as the chain head and link the previous
+            // head (or the -1 empty-chain sentinel) behind it. Chains are
+            // complete only once the kernel finishes; relaxed ordering
+            // suffices because the probe runs in a later command buffer,
+            // after this dispatch completes.
             int old_head = atomic_exchange_explicit(
                 &hash_table[slot].row_index, (int)tid,
                 memory_order_relaxed);
@@ -50,7 +53,10 @@ kernel void merge_hash_build(
                 memory_order_relaxed);
             return;
         }
-        slot = (slot + 1) & mask;
+        if (expected != EMPTY_SLOT) {
+            // Occupied by a different key — linear-probe onward.
+            slot = (slot + 1) & mask;
+        }
     }
 }
 

--- a/Tests/SwiftPandasTests/MetalTests.swift
+++ b/Tests/SwiftPandasTests/MetalTests.swift
@@ -487,6 +487,39 @@ final class MetalMergeTests: XCTestCase {
         XCTAssertEqual(result.rowCount, 5)
     }
 
+    func testInnerJoinHighContentionDuplicateKeys() {
+        // Many build-side rows over few distinct keys drives maximal
+        // concurrent insertion into the same hash slots, exercising the
+        // build kernel's chain push under contention on any GPU width.
+        let rightN = 50_000
+        let keyCount = 4
+
+        var rightIds = [String]()
+        var rightVals = [Double]()
+        for i in 0..<rightN {
+            rightIds.append("k\(i % keyCount)")
+            rightVals.append(Double(i))
+        }
+        let leftIds = (0..<keyCount).map { "k\($0)" }
+
+        let left = DataFrame(columns: [
+            ("id", Column.fromStrings(leftIds)),
+            ("lval", Column.fromDoubles([Double](repeating: 0, count: keyCount))),
+        ])
+        let right = DataFrame(columns: [
+            ("id", Column.fromStrings(rightIds)),
+            ("rval", Column.fromDoubles(rightVals)),
+        ])
+
+        guard let result = MetalMerge.innerJoin(left: left, right: right, on: "id") else {
+            XCTFail("GPU merge returned nil")
+            return
+        }
+
+        // Each right row matches exactly one left row (one left row per key).
+        XCTAssertEqual(result.rowCount, rightN)
+    }
+
     func testMergeIntegration() {
         // Test that df.merge() uses GPU path transparently for inner joins
         let n = 2_000

--- a/docs/superpowers/designs/2026-08-31-issue-27-merge-hash-build-race.md
+++ b/docs/superpowers/designs/2026-08-31-issue-27-merge-hash-build-race.md
@@ -1,0 +1,155 @@
+# Design: `merge_hash_build` duplicate-key race (#27)
+
+## State what the issue is
+
+GPU inner joins silently drop matches whenever the build (right) side has duplicate join keys, and the loss is non-deterministic — the same join returns a different short row count each run.
+
+`merge_hash_build` inserts each right-table row into a hash table; rows sharing a key form a LIFO chain through `chain_next`. The thread that wins the CAS on a slot's key publishes the key first and stores the chain head (its own row index) one instruction later, unconditionally. Any thread carrying the same key that arrives between those two operations sees the published key, takes the duplicate path, and pushes itself onto the chain correctly. The winner's late store then overwrites the chain head with its own row — whose `chain_next` is still the `-1` sentinel — so every row pushed during that window becomes unreachable. The probe kernel walks winner → `-1` and stops.
+
+Verified on this machine (Apple Silicon, current `main`):
+
+- `MetalMergeTests/testInnerJoinDuplicateKeys` — got 3, expected 5
+- `MetalMergeTests/testInnerJoinCorrectness` — got 3,640, expected 40,000 (issue observed 16,460 / 16,080 / 25,200 on the same test)
+
+We are designing the corrected insert path for the build kernel.
+
+## Code in question
+
+The kernel exists **twice** (SPM cannot compile `.metal`, so the same MSL lives in a string literal); any change lands in both:
+
+- `Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal:32-54` — Xcode-compiled copy; buggy winner branch at lines 33-41
+- `Sources/SwiftPandas/Metal/MetalShaders.swift:484-513` — runtime-compiled string copy; buggy winner branch at lines 486-495
+
+```metal
+while (true) {
+    int expected = EMPTY_SLOT;
+    if (atomic_compare_exchange_weak_explicit(
+            &hash_table[slot].key, &expected, code,
+            memory_order_relaxed, memory_order_relaxed)) {
+        atomic_store_explicit(                       // ← clobbers the chain head
+            &hash_table[slot].row_index, (int)tid,
+            memory_order_relaxed);
+        return;
+    }
+    int current = atomic_load_explicit(
+        &hash_table[slot].key, memory_order_relaxed);
+    if (current == code) {
+        int old_head = atomic_exchange_explicit(
+            &hash_table[slot].row_index, (int)tid,
+            memory_order_relaxed);
+        atomic_store_explicit(
+            &chain_next[tid], old_head,
+            memory_order_relaxed);
+        return;
+    }
+    slot = (slot + 1) & mask;
+}
+```
+
+The winner's `atomic_store` assumes the slot is still untouched — but the key became visible to every other thread the moment the CAS landed, so the slot's chain may already hold rows. Interleaving that loses rows (three rows, one key):
+
+1. t0 wins the CAS (`key = code`); `row_index` still `-1`
+2. t1 exchanges in: head = 1, `chain_next[1] = -1`
+3. t2 exchanges in: head = 2, `chain_next[2] = 1`
+4. t0 stores: head = 0, `chain_next[0] = -1` → probe emits row 0 only; rows 1 and 2 are orphaned
+
+Supporting facts, verified:
+
+- `chain_next` is memset to `-1` host-side before the build (`Sources/SwiftPandas/Metal/MetalMerge.swift:128-129`), so an exchange on an untouched slot returns the `-1` sentinel.
+- Build and probe run in separate command buffers, each with `waitUntilCompleted` (`Sources/SwiftPandas/Metal/MetalContext.swift:296-315`), so relaxed atomics need no cross-kernel ordering.
+- The duplicate path and the probe kernel are correct; only the winner branch is wrong.
+
+## Proposed Design 1 — winner pushes instead of storing
+
+Minimal diff: change only the CAS-success branch so the winner links onto whatever the slot holds, exactly like the duplicate path.
+
+BEFORE (`MergeShaders.metal:33-41`, same shape at `MetalShaders.swift:486-495`):
+
+```metal
+        int expected = EMPTY_SLOT;
+        if (atomic_compare_exchange_weak_explicit(
+                &hash_table[slot].key, &expected, code,
+                memory_order_relaxed, memory_order_relaxed)) {
+            atomic_store_explicit(
+                &hash_table[slot].row_index, (int)tid,
+                memory_order_relaxed);
+            return;
+        }
+```
+
+AFTER:
+
+```metal
+        int expected = EMPTY_SLOT;
+        if (atomic_compare_exchange_weak_explicit(
+                &hash_table[slot].key, &expected, code,
+                memory_order_relaxed, memory_order_relaxed)) {
+            // The key is visible to other threads as soon as the CAS lands,
+            // so the slot's chain may already hold rows. Push onto whatever
+            // is there rather than assuming the slot is untouched.
+            int old_head = atomic_exchange_explicit(
+                &hash_table[slot].row_index, (int)tid,
+                memory_order_relaxed);
+            atomic_store_explicit(
+                &chain_next[tid], old_head,
+                memory_order_relaxed);
+            return;
+        }
+```
+
+Why it works: after the key is published, *every* insert into the slot — winner included — is an atomic exchange-and-link. Uncontended, the exchange returns `-1` and the result is byte-identical to today. Contended, the exchange returns the racers' current head and the winner links onto it; no row is ever unreachable because each push atomically threads the previous head behind the new one.
+
+Changes: the two winner branches only (~6 lines each in the two files). This is the fix proposed in the issue, validated there in a standalone harness (0 wrong results in 180 runs).
+
+## Proposed Design 2 — one push path for every row
+
+Restructure the loop so "claim the key" and "find the key already claimed" both fall into a single push sequence. The failed CAS writes the observed key into `expected` (MSL semantics), so the separate re-load disappears.
+
+BEFORE (`MergeShaders.metal:32-54`, same shape at `MetalShaders.swift:484-512`): the full loop shown in *Code in question*.
+
+AFTER:
+
+```metal
+    while (true) {
+        // Claim the slot's key if empty. On failure, `expected` holds the
+        // key currently in the slot.
+        int expected = EMPTY_SLOT;
+        bool claimed = atomic_compare_exchange_weak_explicit(
+                &hash_table[slot].key, &expected, code,
+                memory_order_relaxed, memory_order_relaxed);
+        if (claimed || expected == code) {
+            // This slot owns our key. Every inserting thread pushes itself
+            // the same way: swap our row in as the chain head and link the
+            // previous head (or the -1 sentinel) behind us.
+            int old_head = atomic_exchange_explicit(
+                &hash_table[slot].row_index, (int)tid,
+                memory_order_relaxed);
+            atomic_store_explicit(
+                &chain_next[tid], old_head,
+                memory_order_relaxed);
+            return;
+        }
+        if (expected != EMPTY_SLOT) {
+            // Occupied by a different key — linear-probe onward.
+            slot = (slot + 1) & mask;
+        }
+        // expected == EMPTY_SLOT: the weak CAS failed spuriously; retry the
+        // same slot so one key can never end up split across two slots.
+    }
+```
+
+Why it works: same push invariant as Design 1, but there is only one insert path, so the invariant cannot diverge again. It also closes a second, latent hazard: `atomic_compare_exchange_weak_explicit` is permitted to fail spuriously (there is no strong variant in MSL). The current loop — and Design 1's — responds to any CAS failure by re-loading the key and, on seeing `EMPTY_SLOT`, advancing to the next slot. A spurious failure on an empty slot would therefore seed the same key into a *second* slot; the probe stops after the first matching slot's chain, dropping the second — the same symptom class as #27. Never observed on Apple GPUs, but permitted by the spec. Design 2 retries the same slot instead.
+
+Changes: replace the loop body in both files (~20 lines each); the narrative comments above each copy (`MergeShaders.metal:3-5`, `MetalShaders.swift:440-457`) get updated to describe the single push path.
+
+## Recommendation
+
+**Design 2.**
+
+The bug exists because insertion had two code paths with two different invariants, and the winner's invariant — "the slot is still untouched" — is false from the instant its CAS lands. Design 1 patches that path; Design 2 removes the distinction, leaving one invariant ("publish the key if needed, then push yourself onto the chain") that holds for every thread. One path is also the only version that closes the spurious-CAS-failure hazard, which Design 1 leaves in place.
+
+Cost is negligible: the contended path executes identical atomics to Design 1; the uncontended path gains one `chain_next` store that writes `-1` over the `-1` already memset there. The diff is larger than Design 1's, but the resulting kernel is shorter than today's (the re-load disappears) and every line of it is exercised by the unique-key tests as well as the duplicate-key tests.
+
+## Next steps
+
+Per the working agreement: lock a design in this PR's review, then show the RED tests in this doc (both existing `MetalMergeTests` failures are already RED on `main`; the test phase should also weigh a production-shape stress case — ~18,500 build rows over ~615 keys — since the 3-row test races only narrowly), then add the `/writing-plans` implementation plan to this PR, then implement on explicit go-ahead. Any implementation must change both shader copies in lockstep.

--- a/docs/superpowers/designs/2026-08-31-issue-27-merge-hash-build-race.md
+++ b/docs/superpowers/designs/2026-08-31-issue-27-merge-hash-build-race.md
@@ -142,14 +142,64 @@ Why it works: same push invariant as Design 1, but there is only one insert path
 
 Changes: replace the loop body in both files (~20 lines each); the narrative comments above each copy (`MergeShaders.metal:3-5`, `MetalShaders.swift:440-457`) get updated to describe the single push path.
 
+## Proposed Design 3 — link-before-publish with a CAS-retry push
+
+Proposed by SpyderMYK in the #25 thread (the same defect, reported earlier). Like Design 2 it unifies insertion into one path and retries the slot on a spurious CAS failure, but the chain push is inverted: write `chain_next[tid]` *first*, then publish `tid` as head with a CAS that retries on a stale head.
+
+BEFORE: the full loop shown in *Code in question*.
+
+AFTER:
+
+```metal
+    while (true) {
+        // Claim the slot for this key, or find the slot already holding it.
+        int expected = EMPTY_SLOT;
+        if (!atomic_compare_exchange_weak_explicit(
+                &hash_table[slot].key, &expected, code,
+                memory_order_relaxed, memory_order_relaxed)) {
+            if (expected == EMPTY_SLOT) continue;   // spurious failure — retry this slot
+            if (expected != code) {
+                slot = (slot + 1) & mask;           // different key — linear probe
+                continue;
+            }
+        }
+        // This slot owns our key. Link the current head behind us before
+        // publishing ourselves as head, so the chain is intact at every
+        // instant, not only at kernel completion.
+        int old_head = atomic_load_explicit(
+            &hash_table[slot].row_index, memory_order_relaxed);
+        do {
+            atomic_store_explicit(&chain_next[tid], old_head, memory_order_relaxed);
+        } while (!atomic_compare_exchange_weak_explicit(
+                    &hash_table[slot].row_index, &old_head, (int)tid,
+                    memory_order_relaxed, memory_order_relaxed));
+        return;
+    }
+```
+
+Why it works: `chain_next[tid]` always points at the observed head before the CAS makes `tid` the new head, and the CAS fails and retries whenever the head moved underneath — no push can clobber another, and the list is never transiently broken.
+
+Difference from Design 2: Design 2's single `atomic_exchange` leaves a window where the new head's `chain_next` is still `-1`; that is harmless today only because the probe runs after a full command-buffer barrier. Design 3's invariant holds without that assumption. The cost is a load plus a CAS loop (unbounded retries under contention) where Design 2 pays one wait-free exchange.
+
+Changes: replace the loop body in both files (~22 lines each) plus the same narrative-comment updates as Design 2.
+
 ## Recommendation
 
 **Design 2.**
 
-The bug exists because insertion had two code paths with two different invariants, and the winner's invariant — "the slot is still untouched" — is false from the instant its CAS lands. Design 1 patches that path; Design 2 removes the distinction, leaving one invariant ("publish the key if needed, then push yourself onto the chain") that holds for every thread. One path is also the only version that closes the spurious-CAS-failure hazard, which Design 1 leaves in place.
+All three fix the bug; the choice is about which invariants remain. The bug exists because insertion had two code paths with two different invariants, and the winner's invariant — "the slot is still untouched" — is false from the instant its CAS lands. Design 1 patches that path but keeps the split and the spurious-CAS hazard. Designs 2 and 3 both collapse to one path and close the hazard.
 
-Cost is negligible: the contended path executes identical atomics to Design 1; the uncontended path gains one `chain_next` store that writes `-1` over the `-1` already memset there. The diff is larger than Design 1's, but the resulting kernel is shorter than today's (the re-load disappears) and every line of it is exercised by the unique-key tests as well as the duplicate-key tests.
+Between 2 and 3: Design 3's stronger every-instant chain consistency buys nothing in this system, because the dependency it would remove is load-bearing elsewhere anyway — `merge_hash_probe` reads `chain_next` through a plain non-atomic pointer and assumes a completed build, so build and probe can never share a command buffer without reworking the probe regardless of which push we use. Given that the barrier is a fixed architectural fact (`MetalContext.dispatch` commits and waits per dispatch), Design 2 achieves the same correctness with one wait-free exchange instead of a retry loop, and slightly less code. If the build/probe dispatch structure is ever revisited, that revisit owns the migration to Design 3's push — a comment on the kernel should say so.
+
+Cost versus Design 1 is negligible: the contended path executes identical atomics; the uncontended path gains one `chain_next` store that writes `-1` over the `-1` already memset there. The resulting kernel is shorter than today's (the re-load disappears) and every line of it is exercised by the unique-key tests as well as the duplicate-key tests.
 
 ## Next steps
 
-Per the working agreement: lock a design in this PR's review, then show the RED tests in this doc (both existing `MetalMergeTests` failures are already RED on `main`; the test phase should also weigh a production-shape stress case — ~18,500 build rows over ~615 keys — since the 3-row test races only narrowly), then add the `/writing-plans` implementation plan to this PR, then implement on explicit go-ahead. Any implementation must change both shader copies in lockstep.
+Per the working agreement: lock a design in this PR's review, then show the RED tests in this doc, then add the `/writing-plans` implementation plan to this PR, then implement on explicit go-ahead.
+
+Standing notes for the later phases:
+
+- Both existing `MetalMergeTests` failures are already RED on `main` on this hardware, but their sensitivity is hardware-dependent (they reportedly pass on a narrower GPU). The test phase should add a low-cardinality stress case — many build rows over few distinct keys (e.g. ~100k rows / 8 keys) — as the durable regression guard.
+- Any implementation must change both shader copies in lockstep (`MergeShaders.metal` + the `MetalShaders.swift` string).
+- The reporter in the #25 thread has a ready patch (their Design 3 variant, both copies, plus a stress test) and offered a PR. Accepting it versus implementing in-house is a maintainer choice; either way, the locked design in this PR is the review yardstick.
+- The fix reaches binary consumers (`SWIFTPANDAS_USE_BINARY=1`, e.g. the kiraa engine) only through a tagged release with a rebuilt XCFramework — Package.swift URL/checksum, README version, and `SwiftPandasInfo.version` move together per the release convention.

--- a/docs/superpowers/designs/2026-08-31-issue-27-metal-tests-ci-lane.md
+++ b/docs/superpowers/designs/2026-08-31-issue-27-metal-tests-ci-lane.md
@@ -4,7 +4,7 @@
 
 Both tests that catch the #27 race (`testInnerJoinDuplicateKeys`, `testInnerJoinCorrectness`) predate the report and fail today — yet nothing ever ran them automatically.
 
-One correction to the issue's framing: it attributes this to "the default binary mode (`SWIFTPANDAS_USE_BINARY≠0`)" dropping the test targets. That premise is wrong — `Package.swift:52` reads `useBinary = env == "1"`, so binary mode is strictly opt-in and a plain `swift test` builds from source and includes `MetalMergeTests` (that is how the failures above were reproduced). The actual gap: the repo's only workflow is `.github/workflows/release.yml`, which just updates the Homebrew tap. There is **no CI that builds or tests anything**.
+Context on the issue's framing: the bug was hit downstream, in a repo that imports SwiftPandas as a package. SPM never builds or runs a dependency's test targets, and a binary consumer (`SWIFTPANDAS_USE_BINARY=1`) doesn't even have them in its package graph — so from that vantage "the tests never run" is accurate. Within *this* repo, though, binary mode is strictly opt-in (`Package.swift:52`, `== "1"`) and a plain `swift test` builds from source and runs `MetalMergeTests` — which fail today. The gap is that nothing does so automatically: the repo's only workflow is `.github/workflows/release.yml`, which just updates the Homebrew tap. This repo is the only place these tests can ever execute, and there is **no CI that builds or tests anything**.
 
 We are designing the test lane that closes that gap. Constraint: Metal tests assert `MetalDispatch.isAvailable` and expect a Metal-capable Mac, so the runner choice is the design decision.
 

--- a/docs/superpowers/designs/2026-08-31-issue-27-metal-tests-ci-lane.md
+++ b/docs/superpowers/designs/2026-08-31-issue-27-metal-tests-ci-lane.md
@@ -1,0 +1,57 @@
+# Design: a CI lane that actually runs `MetalMergeTests` (#27, secondary)
+
+## State what the issue is
+
+Both tests that catch the #27 race (`testInnerJoinDuplicateKeys`, `testInnerJoinCorrectness`) predate the report and fail today — yet nothing ever ran them automatically.
+
+One correction to the issue's framing: it attributes this to "the default binary mode (`SWIFTPANDAS_USE_BINARY≠0`)" dropping the test targets. That premise is wrong — `Package.swift:52` reads `useBinary = env == "1"`, so binary mode is strictly opt-in and a plain `swift test` builds from source and includes `MetalMergeTests` (that is how the failures above were reproduced). The actual gap: the repo's only workflow is `.github/workflows/release.yml`, which just updates the Homebrew tap. There is **no CI that builds or tests anything**.
+
+We are designing the test lane that closes that gap. Constraint: Metal tests assert `MetalDispatch.isAvailable` and expect a Metal-capable Mac, so the runner choice is the design decision.
+
+## Code in question
+
+- `.github/workflows/` — contains only `release.yml`; no build/test workflow exists (this is the gap, not a bug in a file).
+- `Package.swift:50-52` — binary consumption is opt-in via `SWIFTPANDAS_USE_BINARY=1`; CI must simply not set it.
+- `Tests/SwiftPandasTests/MetalTests.swift:398-488` — the merge tests a lane must execute.
+
+## Proposed Design 1 — GitHub-hosted Apple-silicon runner
+
+BEFORE: no test workflow.
+
+AFTER: new file `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-15   # Apple-silicon hosted runner
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: swift build
+      - name: Test
+        run: swift test
+```
+
+GitHub's arm64 macOS runners virtualize a paravirtual GPU that exposes Metal, so `MetalDispatch.isAvailable` is expected to hold — but that must be verified with a probe run before relying on the lane (if the VM's Metal support turns out incomplete for compute, the lane would fail on runner capability rather than on code). Zero infrastructure to maintain; runs on every PR, which is the property that would have caught #27.
+
+## Proposed Design 2 — self-hosted runner on a maintainer Mac
+
+BEFORE: no test workflow.
+
+AFTER: the same `ci.yml` with `runs-on: [self-hosted, macOS, ARM64]`, plus a registered runner on real Apple hardware (the same class of machine `scripts/build-release.sh` already assumes).
+
+Guaranteed real Metal — the test environment matches the production environment exactly, including GPU timing characteristics that make the #27 race reproduce. Costs: a machine that must stay online, runner maintenance, and security exposure if the repo ever accepts outside PRs (self-hosted runners execute PR code on the maintainer's hardware).
+
+## Recommendation
+
+**Design 1.** A hosted runner needs no infrastructure and runs on every PR, and the probe run either validates it immediately or fails loudly on the first day — nothing silent. Design 2's only advantage (bare-metal GPU fidelity) matters for performance work, not for correctness tests like the two that catch #27; its maintenance and security costs are permanent. If the probe run shows the hosted VM cannot run the Metal compute kernels, that result comes back to this PR and Design 2 becomes the fallback conversation.
+
+## Next steps
+
+Same gating as the main design doc: this lane gets built only after the design is locked in review. The probe run (a throwaway branch pushing `ci.yml` and observing whether the Metal tests execute rather than skip or crash) is the first implementation step.

--- a/planning/plans/2026-08-31-issue-27-merge-hash-build-race.md
+++ b/planning/plans/2026-08-31-issue-27-merge-hash-build-race.md
@@ -1,0 +1,322 @@
+# merge_hash_build Duplicate-Key Race Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make GPU inner joins return every match when the build (right) side has duplicate join keys, by giving `merge_hash_build` a single insert path in both shader copies.
+
+**Architecture:** The locked design (Design 2 in the spec) collapses the kernel's two insert paths — CAS winner vs. duplicate — into one: claim the slot's key if empty, then *every* thread pushes itself onto the slot's chain via `atomic_exchange` + `chain_next` link. The `-1` sentinel already means "empty chain," so the first inserter needs no special path. A spurious weak-CAS failure retries the same slot. No host Swift, probe kernel, or API changes.
+
+**Tech Stack:** Metal Shading Language (MSL) compute kernels, Swift/XCTest, SwiftPM + XcodeGen.
+
+**Spec:** `docs/superpowers/designs/2026-08-31-issue-27-merge-hash-build-race.md` (Design 2 — locked by maintainer)
+
+## Global Constraints
+
+- The kernel exists twice and MUST change identically in both places: `Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal` (Xcode-only; `exclude:`d in Package.swift) and the string literal in `Sources/SwiftPandas/Metal/MetalShaders.swift` (what actually runs under `swift test` / SPM).
+- MSL device atomics accept ONLY `memory_order_relaxed` — release/acquire will not compile. Relaxed is sound because build and probe run in separate command buffers, each `waitUntilCompleted` (`MetalContext.swift:296-315`).
+- Comments must be timeless: describe what the code does and why for a zero-context reader. Never reference the defect, "the fix," or before/after.
+- Commits: conventional-commit style, Markos is sole author — NO `Co-Authored-By`, `Claude-Session`, or "Generated with" trailers, ever.
+- Environment: Metal-capable Mac; `SWIFTPANDAS_USE_BINARY` must be unset.
+- Execute on a fresh branch off `main` (suggested: `fix/issue-27-merge-hash-build-race`). Every commit leaves the suite green — RED evidence is recorded in the PR, not committed as a failing state.
+- Release/version bump (Package.swift checksum, README, `SwiftPandasInfo.version`, XCFramework) is out of scope — maintainer handles it separately.
+
+---
+
+### Task 1: RED — high-contention regression test
+
+**Files:**
+- Modify: `Tests/SwiftPandasTests/MetalTests.swift` (insert after `testInnerJoinDuplicateKeys`, which ends at line 488)
+
+**Interfaces:**
+- Consumes: `MetalMerge.innerJoin(left:right:on:) -> DataFrame?`, `Column.fromStrings(_:)`, `Column.fromDoubles(_:)`, `DataFrame(columns:)` — all exactly as used by the existing tests in this class.
+- Produces: test method `MetalMergeTests.testInnerJoinHighContentionDuplicateKeys` (Task 2 runs it).
+
+Rationale (from the spec): the two existing duplicate-key tests fail on this machine but reportedly pass on narrower GPUs — their contention is too thin to race reliably everywhere. Many build rows over few distinct keys contends maximally on any Metal device, making this the durable regression guard.
+
+- [ ] **Step 1: Write the test**
+
+Insert after line 488 of `Tests/SwiftPandasTests/MetalTests.swift` (immediately after `testInnerJoinDuplicateKeys`'s closing brace):
+
+```swift
+    func testInnerJoinHighContentionDuplicateKeys() {
+        // Many build-side rows over few distinct keys drives maximal
+        // concurrent insertion into the same hash slots, exercising the
+        // build kernel's chain push under contention on any GPU width.
+        let rightN = 50_000
+        let keyCount = 4
+
+        var rightIds = [String]()
+        var rightVals = [Double]()
+        for i in 0..<rightN {
+            rightIds.append("k\(i % keyCount)")
+            rightVals.append(Double(i))
+        }
+        let leftIds = (0..<keyCount).map { "k\($0)" }
+
+        let left = DataFrame(columns: [
+            ("id", Column.fromStrings(leftIds)),
+            ("lval", Column.fromDoubles([Double](repeating: 0, count: keyCount))),
+        ])
+        let right = DataFrame(columns: [
+            ("id", Column.fromStrings(rightIds)),
+            ("rval", Column.fromDoubles(rightVals)),
+        ])
+
+        guard let result = MetalMerge.innerJoin(left: left, right: right, on: "id") else {
+            XCTFail("GPU merge returned nil")
+            return
+        }
+
+        // Each right row matches exactly one left row (one left row per key).
+        XCTAssertEqual(result.rowCount, rightN)
+    }
+```
+
+Output-capacity sanity (no code needed, just why this passes the overflow guard): `MetalMerge.swift:157` computes `maxOutput = min(leftN * rightN, leftN * 10 + rightN * 10 + 100_000)` = min(200,000, 600,040) = 200,000; expected `outCount` is 50,000, well under it.
+
+- [ ] **Step 2: Run the three duplicate-key tests to verify RED**
+
+Run:
+```bash
+swift test --filter 'MetalMergeTests/(testInnerJoinHighContentionDuplicateKeys|testInnerJoinDuplicateKeys|testInnerJoinCorrectness)'
+```
+
+Expected: ALL THREE FAIL with `XCTAssertEqual failed` on row counts below the expected value (new test: fewer than 50,000; existing: fewer than 5 and fewer than 40,000). Counts vary run to run — that is the race. If the new test PASSES here, it is not contending hard enough: stop and raise `rightN` (e.g. 200,000 / 2 keys) until it fails, before proceeding.
+
+- [ ] **Step 3: Record the RED evidence**
+
+Copy the three failure lines verbatim into the implementation PR description (or a PR comment) under a "RED before fix" heading. Do NOT commit yet — the commit lands with the green implementation in Task 2 so every commit keeps the suite green.
+
+---
+
+### Task 2: GREEN — single insert path in both shader copies
+
+**Files:**
+- Modify: `Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal:32-54` (the insert loop)
+- Modify: `Sources/SwiftPandas/Metal/MetalShaders.swift:484-512` (the same loop in the MSL string)
+- Modify: `Sources/SwiftPandas/Metal/MetalShaders.swift:120-127` (file-level narrative, insert-algorithm steps)
+- Modify: `Sources/SwiftPandas/Metal/MetalShaders.swift:452-456` (merge-section narrative)
+- Test: `Tests/SwiftPandasTests/MetalTests.swift` (from Task 1; no further edits)
+
+**Interfaces:**
+- Consumes: `testInnerJoinHighContentionDuplicateKeys` from Task 1.
+- Produces: the corrected `merge_hash_build` kernel. Kernel signature, buffer indices, `MergeHashEntry` layout, and `chain_next` semantics are UNCHANGED — `merge_hash_probe` and all host code are untouched.
+
+- [ ] **Step 1: Replace the insert loop in `MergeShaders.metal`**
+
+At `Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal`, replace lines 32-54 exactly:
+
+BEFORE:
+```metal
+    while (true) {
+        int expected = EMPTY_SLOT;
+        if (atomic_compare_exchange_weak_explicit(
+                &hash_table[slot].key, &expected, code,
+                memory_order_relaxed, memory_order_relaxed)) {
+            atomic_store_explicit(
+                &hash_table[slot].row_index, (int)tid,
+                memory_order_relaxed);
+            return;
+        }
+        int current = atomic_load_explicit(
+            &hash_table[slot].key, memory_order_relaxed);
+        if (current == code) {
+            int old_head = atomic_exchange_explicit(
+                &hash_table[slot].row_index, (int)tid,
+                memory_order_relaxed);
+            atomic_store_explicit(
+                &chain_next[tid], old_head,
+                memory_order_relaxed);
+            return;
+        }
+        slot = (slot + 1) & mask;
+    }
+```
+
+AFTER:
+```metal
+    while (true) {
+        // Claim the slot's key if empty. On failure `expected` holds the key
+        // currently in the slot; a weak CAS may also fail spuriously, leaving
+        // `expected` == EMPTY_SLOT — retry the same slot in that case so one
+        // key can never occupy two slots.
+        int expected = EMPTY_SLOT;
+        bool claimed = atomic_compare_exchange_weak_explicit(
+                &hash_table[slot].key, &expected, code,
+                memory_order_relaxed, memory_order_relaxed);
+        if (claimed || expected == code) {
+            // The slot owns this key. Every inserting thread pushes its row
+            // the same way: swap it in as the chain head and link the previous
+            // head (or the -1 empty-chain sentinel) behind it. Chains are
+            // complete only once the kernel finishes; relaxed ordering
+            // suffices because the probe runs in a later command buffer,
+            // after this dispatch completes.
+            int old_head = atomic_exchange_explicit(
+                &hash_table[slot].row_index, (int)tid,
+                memory_order_relaxed);
+            atomic_store_explicit(
+                &chain_next[tid], old_head,
+                memory_order_relaxed);
+            return;
+        }
+        if (expected != EMPTY_SLOT) {
+            // Occupied by a different key — linear-probe onward.
+            slot = (slot + 1) & mask;
+        }
+    }
+```
+
+- [ ] **Step 2: Make the identical replacement in the MSL string**
+
+At `Sources/SwiftPandas/Metal/MetalShaders.swift`, replace lines 484-512 (the same loop, currently commented with "Try to claim an empty slot via CAS" / "First row with this key in this slot — store directly" / "Duplicate key — prepend to the chain..." / "Hash collision (different key) — linear probe") with the IDENTICAL code block from Step 1 — same code, same comments, at the string literal's 4-space indent. The two copies must be functionally identical after this step.
+
+- [ ] **Step 3: Update the file-level narrative in `MetalShaders.swift`**
+
+Replace lines 120-127:
+
+BEFORE:
+```
+//   1. Hash the code and probe for the correct slot via linear probing.
+//   2. If the slot is empty (CAS succeeds), store the row index directly.
+//   3. If the slot already contains the same key (duplicate), use
+//      `atomic_exchange` to atomically swap in the new row index while
+//      retrieving the previous head of the chain. The previous head is then
+//      stored in `chain_next[tid]`, forming a singly-linked list of all
+//      right-table rows with the same key. The chain is effectively built
+//      in LIFO (stack) order.
+```
+
+AFTER:
+```
+//   1. Hash the code and probe for the owning slot via linear probing,
+//      claiming the slot's key with a CAS when the slot is empty.
+//   2. Once the slot owns the key, every inserting thread — including the
+//      one that just claimed it — pushes its row onto the slot's chain the
+//      same way: `atomic_exchange` swaps the new row index into the slot
+//      while retrieving the previous head (-1 for an empty chain), which is
+//      then stored in `chain_next[tid]`. This forms a LIFO singly-linked
+//      list of all right-table rows sharing the same key.
+```
+
+- [ ] **Step 4: Update the merge-section narrative in `MetalShaders.swift`**
+
+Replace lines 452-456:
+
+BEFORE:
+```
+    // The hash table stores one slot per unique key. When a duplicate key is
+    // inserted, the new row atomically replaces the slot's row_index (via
+    // atomic_exchange), and the previous row_index is saved in chain_next.
+    // This builds a LIFO singly-linked list of all right-table rows sharing
+    // the same key, enabling many-to-many join semantics in Phase 2.
+```
+
+AFTER:
+```
+    // The hash table stores one slot per unique key. Every insert pushes its
+    // row onto the slot's chain: atomic_exchange swaps the new row_index in
+    // while returning the previous head (-1 for an empty chain), which is
+    // saved in chain_next. This builds a LIFO singly-linked list of all
+    // right-table rows sharing the same key, enabling many-to-many join
+    // semantics in Phase 2. Chains are complete only when this kernel's
+    // dispatch finishes; the probe runs in a separate command buffer after
+    // that (MetalContext.dispatch waits per dispatch), which is what makes
+    // relaxed atomic ordering sufficient throughout.
+```
+
+- [ ] **Step 5: Run the three tests to verify GREEN**
+
+Run:
+```bash
+swift test --filter 'MetalMergeTests/(testInnerJoinHighContentionDuplicateKeys|testInnerJoinDuplicateKeys|testInnerJoinCorrectness)'
+```
+
+Expected: all three PASS (5, 40,000, and 50,000 rows respectively).
+
+- [ ] **Step 6: Verify stability across repeated runs**
+
+The race was non-deterministic, so one green run proves little. Run:
+```bash
+for i in $(seq 1 10); do
+  swift test --filter 'MetalMergeTests' 2>&1 | grep -E "Executed .* failures" | head -1
+done
+```
+
+Expected: 10 lines, every one reporting `0 failures`. Any failure in any iteration means the fix is wrong — stop and re-examine; do not proceed or weaken the tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/SwiftPandas/Metal/Shaders/MergeShaders.metal Sources/SwiftPandas/Metal/MetalShaders.swift Tests/SwiftPandasTests/MetalTests.swift
+git commit -m "fix(Metal): merge_hash_build pushes every row through a single chain insert path"
+```
+
+---
+
+### Task 3: Verification sweep — full suite, Xcode shader compile, copy parity
+
+**Files:**
+- No source changes. Verification only.
+
+**Interfaces:**
+- Consumes: the committed fix from Task 2.
+- Produces: evidence for the implementation PR that both copies compile, all tests pass, and the copies are in lockstep.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+```bash
+swift test 2>&1 | tail -20
+```
+
+Expected: 0 failures across both test targets (library + CLI; the daemon tests exec the freshly built binary). Any failure — including in non-Metal suites — must be investigated before proceeding; if it also fails on `main` unfixed, note it in the PR rather than absorbing it here.
+
+- [ ] **Step 2: Compile the `.metal` copy via Xcode**
+
+`swift test` never compiles `MergeShaders.metal` (it is `exclude:`d from SPM), so an MSL syntax error there would go unnoticed until an Xcode build. Run:
+
+```bash
+xcodebuild build -scheme SwiftPandas -configuration Release 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`. (If the project needs regenerating first: `xcodegen generate`, then rebuild. Never edit the `.xcodeproj` by hand.)
+
+- [ ] **Step 3: Verify the two shader copies are functionally identical**
+
+Run this from the repo root:
+
+```bash
+python3 - <<'EOF'
+import re
+swift = open('Sources/SwiftPandas/Metal/MetalShaders.swift').read()
+metal = ""
+for f in ['GroupByShaders.metal', 'MergeShaders.metal', 'VectorSearchShaders.metal']:
+    metal += open(f'Sources/SwiftPandas/Metal/Shaders/{f}').read() + "\n"
+
+def kernels(src):
+    out = {}
+    for m in re.finditer(r'kernel void (\w+)\(', src):
+        start = src.index('{', m.start())
+        depth, j = 0, start
+        while j < len(src):
+            if src[j] == '{': depth += 1
+            elif src[j] == '}':
+                depth -= 1
+                if depth == 0: break
+            j += 1
+        body = re.sub(r'//.*', '', src[m.start():j+1])
+        out[m.group(1)] = re.sub(r'\s+', ' ', body).strip()
+    return out
+
+ks, km = kernels(swift), kernels(metal)
+assert set(ks) == set(km), (set(ks) ^ set(km))
+bad = [n for n in ks if ks[n] != km[n]]
+print("DRIFTED:", bad) if bad else print("all kernels identical")
+EOF
+```
+
+Expected: `all kernels identical`. Any `DRIFTED` output means Step 1 and Step 2 of Task 2 diverged — fix before opening the PR.
+
+- [ ] **Step 4: Record evidence in the implementation PR**
+
+Paste into the PR description: the RED output from Task 1 Step 3, the GREEN output from Task 2 Step 5, the 10× stability lines from Task 2 Step 6, and the parity/`BUILD SUCCEEDED` confirmations from this task. The PR closes #25 and #27.


### PR DESCRIPTION
Design → plan → implementation thread for the `merge_hash_build` duplicate-key race.

Closes #25, closes #27.

## Contents
- `docs/superpowers/designs/2026-08-31-issue-27-merge-hash-build-race.md` — three candidate designs; **Design 2 locked** (single insert path: claim-or-match the key, then every thread pushes via exchange-and-link).
- `docs/superpowers/designs/2026-08-31-issue-27-metal-tests-ci-lane.md` — CI lane designs (not yet locked; separate decision).
- `planning/plans/2026-08-31-issue-27-merge-hash-build-race.md` — the implementation plan executed below.
- Implementation commit `2b5ebcd`: the Design 2 loop in **both** shader copies (`MergeShaders.metal` + the MSL string in `MetalShaders.swift`), updated narrative comments, and a new high-contention regression test.

## RED before fix (this machine, Apple Silicon)
```
testInnerJoinCorrectness:               XCTAssertEqual failed: ("15920") is not equal to ("40000")
testInnerJoinDuplicateKeys:             XCTAssertEqual failed: ("3") is not equal to ("5")
testInnerJoinHighContentionDuplicateKeys: XCTAssertEqual failed: ("36856") is not equal to ("50000")
```
(new test: 50,000 build rows over 4 keys — maximal same-slot contention, fails loudly regardless of GPU width)

## GREEN after fix
- The three tests above: pass (5 / 40,000 / 50,000).
- Stability: full `MetalMergeTests` (7 tests) run **10×** — 0 failures in all 10 iterations.
- Full suite: **581 tests, 0 failures** (`swift test`).
- Xcode build (`xcodebuild -scheme SwiftPandas -configuration Release`): **BUILD SUCCEEDED** — compiles the `.metal` copy that SPM never touches.
- Shader-copy parity: comment-stripped diff of all 8 kernels between the `.metal` files and the MSL string — **all kernels identical**.

## Out of scope, agreed follow-ups
- Release (version bump + XCFramework rebuild) — after merge.
- Single-sourcing the duplicated shader code — separate design.
- Dead `groupby_hash_insert` kernel/pipeline cleanup — separate issue.