### PR TITLE
release: v0.8.3-beta

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,8 +55,8 @@ let useBinary = ProcessInfo.processInfo.environment["SWIFTPANDAS_USE_BINARY"] ==
 // every tagged release: scripts/build-xcframework.sh prints the new
 // checksum after building, and the asset must be uploaded to the matching
 // GitHub release before consumers can resolve the binary target.
-let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.2-beta/SwiftPandas.xcframework.zip"
-let xcframeworkChecksum = "c2630fefad4f4fd224605c98542743e78bf11cf83404152f508fb12beb761129"
+let xcframeworkURL = "https://github.com/kiraa-ai/kiraa-swift-pandas/releases/download/v0.8.3-beta/SwiftPandas.xcframework.zip"
+let xcframeworkChecksum = "6f8b425c0ed35f02b282ab92ae0be1d902bc3fc6152d57ce5f94f4b1ecc4c8bf"
 
 // ── Source-mode targets ──
 let sourceTargets: [Target] = [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="swift_pandas.png" alt="SwiftPandas" width="400">
 </p>
 
-# SwiftPandas v0.8.2-beta
+# SwiftPandas v0.8.3-beta
 
 > **BETA RELEASE** — This library is under active development and testing. APIs may change between releases. We welcome bug reports and feedback via [GitHub Issues](https://github.com/kiraa-ai/kiraa-swift-pandas/issues).
 
@@ -13,6 +13,10 @@ SwiftPandas provides `DataFrame`, `Series`, and `Index` types for tabular data m
 The `swiftpandas` CLI ships a **resident-memory daemon mode** (`swiftpandas server start`) that lets multiple shell invocations share an in-memory `DataFrameRegistry`, so a load-once → many-pipes workflow is sub-15 ms per transform vs Python pandas's ~650 ms per-invocation cold-start tax. See [docs/SERVER.md](docs/SERVER.md) and the [examples/cli/](examples/cli/) directory for the full surface.
 
 **Want to try it for yourself?** [docs/TUTORIAL.md](docs/TUTORIAL.md) walks you through a complete analytics workflow twice — first in Python with pandas, then in `swiftpandas` running as a Homebrew-installed daemon. Same dataset, same operations, side-by-side timings. ~20 minutes start to finish.
+
+## What's new in v0.8.3-beta
+
+- **Fix: GPU inner joins no longer drop duplicate-key matches** — `merge_hash_build` had a lost-update race: the thread that claimed a hash slot published the key first and stored the chain head one step later, unconditionally, overwriting any same-key rows that chained in during the window; affected joins silently returned a different short row count on every run. Every insert now goes through a single exchange-and-link push, so the chain head is only ever handed off, never overwritten. Adds a high-contention regression test (50,000 build rows over 4 keys). Fixes #27.
 
 ## What's new in v0.8.2-beta
 
@@ -226,7 +230,7 @@ SwiftPandas supports two SwiftPM consumption modes from a single `Package.swift`
 
 ### Option A — Source build (default)
 
-Add SwiftPandas to your `Package.swift` and pin to the v0.8.2-beta tag (or track `main` for development):
+Add SwiftPandas to your `Package.swift` and pin to the v0.8.3-beta tag (or track `main` for development):
 
 ```swift
 // swift-tools-version: 5.9
@@ -237,7 +241,7 @@ let package = Package(
     platforms: [.macOS(.v13), .iOS(.v16)],
     dependencies: [
         // Recommended: pin to a tagged release
-        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.2-beta"),
+        .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", exact: "0.8.3-beta"),
 
         // Or track the latest development:
         // .package(url: "https://github.com/kiraa-ai/kiraa-swift-pandas.git", branch: "main"),

--- a/Sources/SwiftPandas/SwiftPandas.swift
+++ b/Sources/SwiftPandas/SwiftPandas.swift
@@ -49,5 +49,5 @@ public enum SwiftPandasInfo {
     /// interface, so clients inline the literal and never need the symbol —
     /// the failure mode is impossible by construction, in any build mode.
     @inlinable
-    public static var version: String { "0.8.2-beta" }
+    public static var version: String { "0.8.3-beta" }
 }

--- a/Tests/SwiftPandasTests/SwiftPandasTests.swift
+++ b/Tests/SwiftPandasTests/SwiftPandasTests.swift
@@ -43,7 +43,7 @@ import XCTest
 /// Ensures the public `SwiftPandasInfo.version` string matches the expected release.
 final class SwiftPandasTests: XCTestCase {
     func testVersion() {
-        XCTAssertEqual(SwiftPandasInfo.version, "0.8.2-beta")
+        XCTAssertEqual(SwiftPandasInfo.version, "0.8.3-beta")
     }
 }
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -114,7 +114,7 @@ For projects without a Package manifest — a pure-Xcode app, a workspace, or so
 
 ```bash
 # Latest stable XCFramework as of writing:
-gh release download v0.8.2-beta \
+gh release download v0.8.3-beta \
   --repo kiraa-ai/kiraa-swift-pandas \
   --pattern 'SwiftPandas.xcframework.zip'
 unzip SwiftPandas.xcframework.zip
@@ -123,7 +123,7 @@ unzip SwiftPandas.xcframework.zip
 
 Or download from <https://github.com/kiraa-ai/kiraa-swift-pandas/releases> in the browser.
 
-> **Note**: v0.8.2-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
+> **Note**: v0.8.3-beta ships a full library XCFramework (macOS arm64+x86_64, iOS device, iOS simulator) including the vector column type, similarity search, and SPB binary IO — see [vectors.md](vectors.md).
 
 Move the unzipped `SwiftPandas.xcframework` into your project — somewhere committed-or-not depending on your preference. A common layout:
 
@@ -205,15 +205,15 @@ Each library-binary release requires running `scripts/build-xcframework.sh`. The
 
 ```bash
 # 1. Make sure you're on the tag you want to publish.
-git checkout v0.8.2-beta
+git checkout v0.8.3-beta
 
 # 2. Build, upload to the matching GitHub release, and auto-update
 #    Package.swift's url+checksum constants in one shot.
-scripts/build-xcframework.sh --release-tag v0.8.2-beta --update-package-swift
+scripts/build-xcframework.sh --release-tag v0.8.3-beta --update-package-swift
 
 # 3. Commit and push the Package.swift bump.
 git add Package.swift
-git commit -m "v0.8.2-beta: refresh XCFramework binary"
+git commit -m "v0.8.3-beta: refresh XCFramework binary"
 git push origin main
 
 # 4. Verify binary mode resolves cleanly:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@ Format for each item:
 
 ---
 
-## Where we are today (v0.8.2-beta)
+## Where we are today (v0.8.3-beta)
 
 | Capability | Status |
 |---|---|

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -491,7 +491,7 @@ The repo ships **twelve** demo scripts under `examples/cli/`, each comparing one
 
 ```bash
 # If you didn't clone the repo, grab them:
-gh release download v0.8.2-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
+gh release download v0.8.3-beta --repo kiraa-ai/kiraa-swift-pandas --pattern '*.zip'
 # Or just `git clone https://github.com/kiraa-ai/kiraa-swift-pandas.git`
 
 # Then:


### PR DESCRIPTION
Version bump + XCFramework pin for v0.8.3-beta (GPU inner join duplicate-key race fix, #27/#25, merged in #28). Checksum 6f8b425c0ed35f02b282ab92ae0be1d902bc3fc6152d57ce5f94f4b1ecc4c8bf. Follows the v0.8.2-beta release pattern (#26).